### PR TITLE
fix: onboarding swipe gestures, smooth transitions, and safe areas

### DIFF
--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/onboarding/OnboardingScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/onboarding/OnboardingScreen.kt
@@ -85,11 +85,15 @@ fun OnboardingScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             // ── Top bar: pronunciation (left) + Skip (right) ──
+            // Fixed height so pronunciation appearing/disappearing
+            // doesn't resize the pager and cause a layout shift.
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .statusBarsPadding()
-                    .padding(top = 8.dp, start = 24.dp, end = 24.dp)
+                    .height(40.dp)
+                    .padding(start = 24.dp, end = 24.dp),
+                contentAlignment = Alignment.Center
             ) {
                 // Pronunciation — discrete, docked top-left on cachets page
                 if (page.pronunciation != null) {
@@ -130,8 +134,6 @@ fun OnboardingScreen(
                 }
             }
 
-            Spacer(modifier = Modifier.weight(0.2f))
-
             // ── Swipeable page content ──
             HorizontalPager(
                 state = pagerState,
@@ -140,13 +142,17 @@ fun OnboardingScreen(
                     .weight(1f)
             ) { pageIndex ->
                 val p = pages[pageIndex]
+                // Fixed-height sections so all pages have identical geometry.
+                // Weighted spacers are avoided — they cause layout shifts
+                // when text content has different intrinsic heights.
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(horizontal = 24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
                 ) {
-                    // Illustration — consistent 200dp height for smooth transitions
+                    // Illustration
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -161,27 +167,39 @@ fun OnboardingScreen(
                         }
                     }
 
-                    Spacer(modifier = Modifier.weight(0.3f))
+                    Spacer(modifier = Modifier.height(24.dp))
 
                     // Title
-                    Text(
-                        text = p.title,
-                        style = MaterialTheme.typography.displaySmall.copy(fontSize = 28.sp),
-                        color = Color.White,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth()
-                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(72.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = p.title,
+                            style = MaterialTheme.typography.displaySmall.copy(fontSize = 28.sp),
+                            color = Color.White,
+                            textAlign = TextAlign.Center
+                        )
+                    }
 
                     Spacer(modifier = Modifier.height(12.dp))
 
                     // Description
-                    Text(
-                        text = p.description,
-                        style = MaterialTheme.typography.bodyLarge.copy(fontSize = 15.sp),
-                        color = Color(0xFF94A3B8),
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth()
-                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(72.dp),
+                        contentAlignment = Alignment.TopCenter
+                    ) {
+                        Text(
+                            text = p.description,
+                            style = MaterialTheme.typography.bodyLarge.copy(fontSize = 15.sp),
+                            color = Color(0xFF94A3B8),
+                            textAlign = TextAlign.Center
+                        )
+                    }
 
                     Spacer(modifier = Modifier.height(16.dp))
 
@@ -191,8 +209,6 @@ fun OnboardingScreen(
                         title = p.keyTitle,
                         subtitle = p.keySubtitle
                     )
-
-                    Spacer(modifier = Modifier.weight(0.4f))
                 }
             }
 

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/onboarding/OnboardingScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/onboarding/OnboardingScreen.kt
@@ -81,16 +81,14 @@ fun OnboardingScreen(
         color = BrandPrimary
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 24.dp),
+            modifier = Modifier.fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             // ── Top bar: pronunciation (left) + Skip (right) ──
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 16.dp)
+                    .padding(top = 16.dp, start = 24.dp, end = 24.dp)
             ) {
                 // Pronunciation — discrete, docked top-left on cachets page
                 if (page.pronunciation != null) {
@@ -136,19 +134,30 @@ fun OnboardingScreen(
             // ── Swipeable page content ──
             HorizontalPager(
                 state = pagerState,
-                modifier = Modifier.weight(1f)
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
             ) { pageIndex ->
                 val p = pages[pageIndex]
                 Column(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 24.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    // Illustration
-                    when (pageIndex) {
-                        0 -> DemandTrustIllustration()
-                        1 -> BrandShieldMark(size = 160.dp)
-                        2 -> CachetCardsIllustration()
-                        3 -> ReceiptListIllustration()
+                    // Illustration — consistent 200dp height for smooth transitions
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(200.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        when (pageIndex) {
+                            0 -> DemandTrustIllustration()
+                            1 -> BrandShieldMark(size = 160.dp)
+                            2 -> CachetCardsIllustration()
+                            3 -> ReceiptListIllustration()
+                        }
                     }
 
                     Spacer(modifier = Modifier.weight(0.3f))
@@ -200,16 +209,18 @@ fun OnboardingScreen(
             Spacer(modifier = Modifier.height(20.dp))
 
             // ── CTA ──
-            SealButton(
-                text = page.ctaLabel,
-                onClick = {
-                    if (currentPage < pages.lastIndex) {
-                        scope.launch { pagerState.animateScrollToPage(currentPage + 1) }
-                    } else {
-                        onComplete()
+            Box(modifier = Modifier.padding(horizontal = 24.dp)) {
+                SealButton(
+                    text = page.ctaLabel,
+                    onClick = {
+                        if (currentPage < pages.lastIndex) {
+                            scope.launch { pagerState.animateScrollToPage(currentPage + 1) }
+                        } else {
+                            onComplete()
+                        }
                     }
-                }
-            )
+                )
+            }
 
             Spacer(modifier = Modifier.height(24.dp))
         }
@@ -294,8 +305,10 @@ private fun CachetCardsIllustration() {
 @Composable
 private fun ReceiptListIllustration() {
     Column(
-        modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(200.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically)
     ) {
         ReceiptMockRow(CachetType.CHILDCARE, "Childcare check — Mar 15", "Parents Association", "Logged", BrandAccent)
         ReceiptMockRow(CachetType.AGE, "Age verification — Mar 12", "Concert venue", "Logged", BrandAccent)

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/onboarding/OnboardingScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/onboarding/OnboardingScreen.kt
@@ -88,7 +88,8 @@ fun OnboardingScreen(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 16.dp, start = 24.dp, end = 24.dp)
+                    .statusBarsPadding()
+                    .padding(top = 8.dp, start = 24.dp, end = 24.dp)
             ) {
                 // Pronunciation — discrete, docked top-left on cachets page
                 if (page.pronunciation != null) {
@@ -222,7 +223,9 @@ fun OnboardingScreen(
                 )
             }
 
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier
+                .navigationBarsPadding()
+                .height(8.dp))
         }
     }
 }


### PR DESCRIPTION
## Summary
- Move horizontal padding inside pager pages so `HorizontalPager` gets full-width touch surface for swipe detection
- Wrap all illustrations in consistent 200dp containers to prevent layout jumps between pages
- Fix top bar to 40dp height so pronunciation badge appearing/disappearing doesn't resize the pager mid-swipe
- Replace hardcoded top/bottom padding with `statusBarsPadding()` / `navigationBarsPadding()` for Samsung S24 Ultra and similar devices

Follow-up to #107. See #109 for full edge-to-edge migration across all screens.

## Test plan
- [ ] Swipe through all 4 onboarding screens — transitions should be smooth with no vertical shift
- [ ] Page 3→4 specifically: no upward bump when pronunciation badge disappears
- [ ] Skip button and CTA button have proper spacing from system bars on real device
- [ ] "Next" and "Get Started" buttons still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)