### PR TITLE
feat: liveness check gate + deep link holder flow (#58, #60)

### DIFF
--- a/design/wireframes/cachet-03-incoming-request-biometric.svg
+++ b/design/wireframes/cachet-03-incoming-request-biometric.svg
@@ -1,0 +1,148 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 375 812" width="375" height="812">
+  <!--
+    SCREEN 3 (biometric variant): Incoming Request — high-value pack
+    Same as cachet-03-incoming-request.svg but with biometric consent section.
+    Only shown when the CachPack requires liveness (Childcare, Seller, Identity).
+
+    BIPA compliance: explicit biometric consent BEFORE the user commits.
+    The "How this works" section and CTA text change make the face scan
+    consent part of the single decision, not a separate interstitial.
+
+    Design tokens:
+      SurfaceBackground   #FAFAF9
+      BrandPrimary         #1E293B
+      BrandAccent          #10B981
+      BrandWarm            #F97068
+      TextPrimary          #1C1917
+      TextSecondary        #57534E
+      TextTertiary         #A8A29E
+      SurfaceCard          #FFFFFF
+      SurfaceElevated      #F5F5F4
+      SurfaceBorder        #E7E5E4
+      TrustPendingBg       #FEF3C7
+      TrustPendingText     #92400E
+  -->
+
+  <defs>
+    <symbol id="childcare-shield" viewBox="0 0 400 520">
+      <path d="M 200 35 C 240 60, 348 63, 366 64 V 239 C 366 337, 296 414, 200 453 C 104 414, 34 337, 34 239 V 64 C 52 63, 160 60, 200 35 Z" fill="#D4748E"/>
+      <path d="M 200 51 C 234 68, 334 74, 354 77 V 236 C 354 326, 288 397, 200 434 C 112 397, 46 326, 46 236 V 77 C 66 74, 166 68, 200 51 Z" fill="#B85578"/>
+      <path d="M 200 59 C 230 69, 328 80, 350 79 V 236 C 350 322, 286 393, 200 430 C 114 393, 50 322, 50 236 V 79 C 72 80, 170 69, 200 59 Z" fill="#D88AA0"/>
+      <path d="M 200 67 C 228 77, 322 85, 342 88 V 236 C 342 318, 280 386, 200 420 C 120 386, 58 318, 58 236 V 88 C 78 85, 172 77, 200 67 Z" fill="#263347"/>
+      <path d="M 200 67 C 172 77, 78 85, 58 88 V 236 C 58 318, 120 386, 200 420 Z" fill="#2D3B52"/>
+      <path d="M 200 142 C 280 142, 330 165, 326 278 C 324 347, 268 388, 200 422 Z" fill="#D85B8A"/>
+      <path d="M 200 142 C 120 142, 70 165, 74 278 C 76 347, 132 388, 200 422 Z" fill="#E06B96"/>
+      <path d="M 274 334 A 108 117 0 1 0 126 334" fill="none" stroke="#fff" stroke-width="61" stroke-linecap="round"/>
+      <g transform="matrix(1.3514, 0, 0, 1.3514, -70.28, -51.0)">
+        <circle cx="200" cy="222" r="36" fill="none" stroke="#fff" stroke-width="5" opacity="0.9"/>
+        <circle cx="186" cy="214" r="4" fill="#fff" opacity="0.9"/>
+        <circle cx="214" cy="214" r="4" fill="#fff" opacity="0.9"/>
+        <path d="M 186,234 Q 200,248 214,234" fill="none" stroke="#fff" stroke-width="3.5" stroke-linecap="round" opacity="0.85"/>
+        <path d="M 183,188 Q 192,172 200,182 Q 208,172 217,188" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+      </g>
+    </symbol>
+  </defs>
+
+  <!-- Phone background -->
+  <rect width="375" height="812" rx="40" fill="#FAFAF9"/>
+
+  <!-- Status bar -->
+  <text x="30" y="52" font-family="Inter, sans-serif" font-size="14" font-weight="600" fill="#1C1917">9:41</text>
+  <circle cx="320" cy="48" r="4" fill="#10B981"/>
+  <rect x="332" y="44" width="20" height="8" rx="2" fill="#1C1917"/>
+
+  <!-- Close button -->
+  <text x="350" y="95" font-family="Inter, sans-serif" font-size="16" fill="#A8A29E">&#x2715;</text>
+
+  <!-- ═══════════════════════════════════════ -->
+  <!-- SECTION 1: WHO + WHAT (unchanged)       -->
+  <!-- ═══════════════════════════════════════ -->
+
+  <!-- Shield + ? badge -->
+  <use href="#childcare-shield" x="158" y="88" width="60" height="78"/>
+  <circle cx="212" cy="152" r="22" fill="#FFFFFF" stroke="#E7E5E4" stroke-width="2"/>
+  <text x="212" y="160" text-anchor="middle" font-family="Inter, sans-serif" font-size="18" font-weight="700" fill="#1E293B">?</text>
+
+  <text x="188" y="191" text-anchor="middle" font-family="Inter, sans-serif" font-size="22" font-weight="700" fill="#1C1917">Verification Request</text>
+  <text x="188" y="215" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" fill="#57534E">Someone wants to know:</text>
+
+  <!-- Question pill -->
+  <rect x="32" y="230" width="311" height="48" rx="16" fill="#1E293B"/>
+  <text x="188" y="260" text-anchor="middle" font-family="Inter, sans-serif" font-size="18" font-weight="600" fill="#FFFFFF">Are you safe for childcare?</text>
+
+  <!-- ═══════════════════════════════════════ -->
+  <!-- SECTION 2: WHAT THEY'LL LEARN           -->
+  <!-- ═══════════════════════════════════════ -->
+
+  <text x="24" y="310" font-family="Inter, sans-serif" font-size="13" font-weight="600" fill="#1C1917">They will learn:</text>
+  <text x="24" y="326" font-family="Inter, sans-serif" font-size="12" fill="#57534E">Only these facts — nothing more</text>
+
+  <!-- Predicate list (compact: 4 items) -->
+  <rect x="16" y="340" width="343" height="182" rx="16" fill="#FFFFFF" stroke="#E7E5E4" stroke-width="1"/>
+
+  <!-- Predicate 1 -->
+  <circle cx="40" cy="367" r="10" fill="#ECFDF5"/>
+  <text x="40" y="371" text-anchor="middle" font-family="Inter, sans-serif" font-size="11" fill="#10B981">&#x2713;</text>
+  <text x="58" y="364" font-family="Inter, sans-serif" font-size="13" font-weight="500" fill="#1C1917">You are 18 or older</text>
+  <text x="58" y="378" font-family="Inter, sans-serif" font-size="10" fill="#A8A29E">Your exact age will NOT be shared</text>
+  <line x1="36" y1="393" x2="340" y2="393" stroke="#F5F5F4" stroke-width="1"/>
+
+  <!-- Predicate 2 -->
+  <circle cx="40" cy="411" r="10" fill="#ECFDF5"/>
+  <text x="40" y="415" text-anchor="middle" font-family="Inter, sans-serif" font-size="11" fill="#10B981">&#x2713;</text>
+  <text x="58" y="408" font-family="Inter, sans-serif" font-size="13" font-weight="500" fill="#1C1917">Your identity is verified</text>
+  <text x="58" y="422" font-family="Inter, sans-serif" font-size="10" fill="#A8A29E">Your name will NOT be shared</text>
+  <line x1="36" y1="437" x2="340" y2="437" stroke="#F5F5F4" stroke-width="1"/>
+
+  <!-- Predicate 3 -->
+  <circle cx="40" cy="455" r="10" fill="#ECFDF5"/>
+  <text x="40" y="459" text-anchor="middle" font-family="Inter, sans-serif" font-size="11" fill="#10B981">&#x2713;</text>
+  <text x="58" y="452" font-family="Inter, sans-serif" font-size="13" font-weight="500" fill="#1C1917">No criminal record</text>
+  <text x="58" y="466" font-family="Inter, sans-serif" font-size="10" fill="#A8A29E">Only a clear/not-clear result</text>
+  <line x1="36" y1="481" x2="340" y2="481" stroke="#F5F5F4" stroke-width="1"/>
+
+  <!-- Predicate 4 -->
+  <circle cx="40" cy="499" r="10" fill="#ECFDF5"/>
+  <text x="40" y="503" text-anchor="middle" font-family="Inter, sans-serif" font-size="11" fill="#10B981">&#x2713;</text>
+  <text x="58" y="496" font-family="Inter, sans-serif" font-size="13" font-weight="500" fill="#1C1917">2+ verified references</text>
+  <text x="58" y="510" font-family="Inter, sans-serif" font-size="10" fill="#A8A29E">Referee names will NOT be shared</text>
+
+  <!-- ═══════════════════════════════════════ -->
+  <!-- SECTION 3: BIOMETRIC REQUIREMENT        -->
+  <!-- Only shown when CachPack requires       -->
+  <!-- liveness. This IS the BIPA consent.     -->
+  <!-- ═══════════════════════════════════════ -->
+
+  <text x="24" y="554" font-family="Inter, sans-serif" font-size="13" font-weight="600" fill="#1C1917">Also required:</text>
+
+  <rect x="16" y="564" width="343" height="64" rx="12" fill="#FEF3C7" stroke="#FCD34D" stroke-width="1"/>
+
+  <!-- Face scan icon (simple face outline) -->
+  <circle cx="44" cy="596" r="14" fill="none" stroke="#92400E" stroke-width="1.5"/>
+  <circle cx="39" cy="592" r="2" fill="#92400E"/>
+  <circle cx="49" cy="592" r="2" fill="#92400E"/>
+  <path d="M 39,601 Q 44,606 49,601" fill="none" stroke="#92400E" stroke-width="1.5" stroke-linecap="round"/>
+
+  <text x="66" y="586" font-family="Inter, sans-serif" font-size="12" font-weight="600" fill="#92400E">A face scan to confirm you are the holder</text>
+  <text x="66" y="601" font-family="Inter, sans-serif" font-size="11" fill="#92400E">Processed by Veriff · facial data is not stored</text>
+  <text x="66" y="616" font-family="Inter, sans-serif" font-size="11" fill="#92400E">after verification</text>
+
+  <!-- ═══════════════════════════════════════ -->
+  <!-- SECTION 4: ACTION                       -->
+  <!-- CTA text makes face scan consent        -->
+  <!-- explicit in the act itself              -->
+  <!-- ═══════════════════════════════════════ -->
+
+  <rect x="16" y="644" width="343" height="56" rx="28" fill="#10B981"/>
+  <text x="188" y="678" text-anchor="middle" font-family="Inter, sans-serif" font-size="16" font-weight="600" fill="#FFFFFF">Verify with Face Scan</text>
+
+  <rect x="16" y="708" width="343" height="36" rx="18" fill="none"/>
+  <text x="188" y="732" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" font-weight="500" fill="#F97068">Decline</text>
+
+  <!-- ═══════════════════════════════════════ -->
+  <!-- SECTION 5: TERMS (below CTA)            -->
+  <!-- ═══════════════════════════════════════ -->
+
+  <rect x="16" y="748" width="343" height="40" rx="10" fill="#F5F5F4"/>
+  <text x="188" y="773" text-anchor="middle" font-family="Inter, sans-serif" font-size="11" fill="#57534E"><tspan fill="#10B981">&#x2713;</tspan> Transparency log: results kept for <tspan font-weight="600" fill="#1C1917">90 days</tspan></text>
+</svg>

--- a/design/wireframes/cachet-03b-liveness-check.svg
+++ b/design/wireframes/cachet-03b-liveness-check.svg
@@ -4,9 +4,20 @@
     On the HOLDER's phone — after they consented on the Incoming Request screen.
     High-value CachPack requires proof of physical presence before KB-JWT signing.
     Front camera activates for a Veriff liveness session.
+
+    Design tokens (from Color.kt):
+      BrandPrimaryDark  #0F172A   background
+      BrandPrimary      #1E293B   card/camera bg
+      BrandAccent       #10B981   active step, scanning brackets
+      BrandAccentLight  #34D399   active step glow
+      BrandWarm         #F97068   (not used on this screen)
+      SurfaceBorderDark #334155   borders, connectors, pending step
+      TextSecondaryDark #A8A29E   subtitle text
+      TextTertiaryDark  #64748B   hint text, camera placeholder
+      TextOnBrand       #FFFFFF   headings, step icons
   -->
 
-  <!-- Phone background — dark to focus on camera -->
+  <!-- Phone background — BrandPrimaryDark -->
   <rect width="375" height="812" rx="40" fill="#0F172A"/>
 
   <!-- Status bar -->
@@ -14,8 +25,9 @@
   <circle cx="320" cy="48" r="4" fill="#10B981"/>
   <rect x="332" y="44" width="20" height="8" rx="2" fill="#FFFFFF"/>
 
-  <!-- Back arrow (returns to consent screen) -->
-  <text x="30" y="95" font-family="Inter, sans-serif" font-size="20" fill="#94A3B8">&#x2190;</text>
+  <!-- Top bar: Back arrow (left) + Close X (right) -->
+  <text x="30" y="95" font-family="Inter, sans-serif" font-size="20" fill="#A8A29E">&#x2190;</text>
+  <text x="340" y="95" text-anchor="middle" font-family="Inter, sans-serif" font-size="18" font-weight="500" fill="#A8A29E">&#x2715;</text>
 
   <!-- Step indicator: Consent [done] > Liveness [active] > Result [pending] -->
   <circle cx="148" cy="90" r="8" fill="#10B981"/>
@@ -27,8 +39,9 @@
   <circle cx="228" cy="90" r="8" fill="#334155"/>
 
   <!-- Header text -->
-  <text x="188" y="138" text-anchor="middle" font-family="Inter, sans-serif" font-size="22" font-weight="700" fill="#FFFFFF">Prove it's you</text>
-  <text x="188" y="162" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" fill="#94A3B8">A quick liveness check is required for</text>
+  <text x="188" y="138" text-anchor="middle" font-family="Inter, sans-serif" font-size="22" font-weight="700" fill="#FFFFFF">Prove it&#x2019;s you</text>
+  <text x="188" y="162" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" fill="#A8A29E">A quick identity check is required for</text>
+  <!-- Pack name: color is dynamic per cachet type (shown here as Childcare) -->
   <text x="188" y="180" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" font-weight="600" fill="#D88AA0">Childcare Readiness</text>
 
   <!-- Camera viewfinder — large circle for face framing -->
@@ -43,29 +56,23 @@
   <circle cx="196" cy="358" r="3" fill="#64748B" opacity="0.5"/>
   <path d="M 178,378 Q 188,390 198,378" fill="none" stroke="#64748B" stroke-width="1.5" stroke-linecap="round" opacity="0.5"/>
 
-  <!-- Scanning animation hint — corner brackets around the face area -->
-  <!-- Top-left -->
+  <!-- Scanning animation hint — corner brackets (BrandAccent) -->
   <path d="M 108 285 L 108 270 Q 108 260, 118 260 L 133 260" fill="none" stroke="#10B981" stroke-width="3" stroke-linecap="round"/>
-  <!-- Top-right -->
   <path d="M 268 285 L 268 270 Q 268 260, 258 260 L 243 260" fill="none" stroke="#10B981" stroke-width="3" stroke-linecap="round"/>
-  <!-- Bottom-left -->
   <path d="M 108 495 L 108 510 Q 108 520, 118 520 L 133 520" fill="none" stroke="#10B981" stroke-width="3" stroke-linecap="round"/>
-  <!-- Bottom-right -->
   <path d="M 268 495 L 268 510 Q 268 520, 258 520 L 243 520" fill="none" stroke="#10B981" stroke-width="3" stroke-linecap="round"/>
 
   <!-- Instruction text below viewfinder -->
   <text x="188" y="570" text-anchor="middle" font-family="Inter, sans-serif" font-size="15" font-weight="500" fill="#FFFFFF">Position your face in the frame</text>
   <text x="188" y="592" text-anchor="middle" font-family="Inter, sans-serif" font-size="13" fill="#64748B">Look straight at the camera and hold still</text>
 
-  <!-- Why this is needed — trust explanation -->
+  <!-- Why this is needed — trust explanation card (BrandPrimary bg, SurfaceBorderDark stroke) -->
   <rect x="32" y="620" width="311" height="60" rx="12" fill="#1E293B" stroke="#334155" stroke-width="1"/>
   <text x="56" y="645" font-family="Inter, sans-serif" font-size="20" fill="#F59E0B">&#x1F6E1;</text>
-  <text x="80" y="643" font-family="Inter, sans-serif" font-size="12" fill="#94A3B8">This check ensures only</text>
-  <text x="234" y="643" font-family="Inter, sans-serif" font-size="12" font-weight="600" fill="#FFFFFF">you</text>
-  <text x="248" y="643" font-family="Inter, sans-serif" font-size="12" fill="#94A3B8">can sign</text>
-  <text x="80" y="663" font-family="Inter, sans-serif" font-size="12" fill="#94A3B8">this high-value verification response.</text>
+  <text x="80" y="643" font-family="Inter, sans-serif" font-size="12" fill="#A8A29E">This check ensures only <tspan font-weight="600" fill="#FFFFFF">you</tspan> can sign</text>
+  <text x="80" y="663" font-family="Inter, sans-serif" font-size="12" fill="#A8A29E">this high-value verification response.</text>
 
-  <!-- Cancel button -->
-  <rect x="32" y="704" width="311" height="44" rx="22" fill="none" stroke="#475569" stroke-width="1"/>
-  <text x="188" y="731" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" font-weight="500" fill="#94A3B8">Cancel</text>
+  <!-- Cancel button (outlined, SurfaceBorderDark stroke, TextSecondaryDark text) -->
+  <rect x="32" y="704" width="311" height="44" rx="22" fill="none" stroke="#334155" stroke-width="1"/>
+  <text x="188" y="731" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" font-weight="500" fill="#A8A29E">Cancel</text>
 </svg>

--- a/design/wireframes/cachet-03b-liveness-check.svg
+++ b/design/wireframes/cachet-03b-liveness-check.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 375 812" width="375" height="812">
+  <!--
+    SCREEN 3b: Liveness Check
+    On the HOLDER's phone — after they consented on the Incoming Request screen.
+    High-value CachPack requires proof of physical presence before KB-JWT signing.
+    Front camera activates for a Veriff liveness session.
+  -->
+
+  <!-- Phone background — dark to focus on camera -->
+  <rect width="375" height="812" rx="40" fill="#0F172A"/>
+
+  <!-- Status bar -->
+  <text x="30" y="52" font-family="Inter, sans-serif" font-size="14" font-weight="600" fill="#FFFFFF">9:41</text>
+  <circle cx="320" cy="48" r="4" fill="#10B981"/>
+  <rect x="332" y="44" width="20" height="8" rx="2" fill="#FFFFFF"/>
+
+  <!-- Back arrow (returns to consent screen) -->
+  <text x="30" y="95" font-family="Inter, sans-serif" font-size="20" fill="#94A3B8">&#x2190;</text>
+
+  <!-- Step indicator: Consent [done] > Liveness [active] > Result [pending] -->
+  <circle cx="148" cy="90" r="8" fill="#10B981"/>
+  <text x="148" y="94" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="700" fill="#FFFFFF">&#x2713;</text>
+  <line x1="156" y1="90" x2="181" y2="90" stroke="#334155" stroke-width="2"/>
+  <circle cx="188" cy="90" r="8" fill="#10B981" stroke="#34D399" stroke-width="2"/>
+  <circle cx="188" cy="90" r="3" fill="#FFFFFF"/>
+  <line x1="196" y1="90" x2="221" y2="90" stroke="#334155" stroke-width="2"/>
+  <circle cx="228" cy="90" r="8" fill="#334155"/>
+
+  <!-- Header text -->
+  <text x="188" y="138" text-anchor="middle" font-family="Inter, sans-serif" font-size="22" font-weight="700" fill="#FFFFFF">Prove it's you</text>
+  <text x="188" y="162" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" fill="#94A3B8">A quick liveness check is required for</text>
+  <text x="188" y="180" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" font-weight="600" fill="#D88AA0">Childcare Readiness</text>
+
+  <!-- Camera viewfinder — large circle for face framing -->
+  <circle cx="188" cy="390" r="130" fill="#1E293B" stroke="#334155" stroke-width="2"/>
+
+  <!-- Face outline guide (dashed) -->
+  <ellipse cx="188" cy="380" rx="70" ry="90" fill="none" stroke="#64748B" stroke-width="1.5" stroke-dasharray="8 6" opacity="0.6"/>
+
+  <!-- Camera icon in center (placeholder for live feed) -->
+  <circle cx="188" cy="365" r="18" fill="none" stroke="#64748B" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="180" cy="358" r="3" fill="#64748B" opacity="0.5"/>
+  <circle cx="196" cy="358" r="3" fill="#64748B" opacity="0.5"/>
+  <path d="M 178,378 Q 188,390 198,378" fill="none" stroke="#64748B" stroke-width="1.5" stroke-linecap="round" opacity="0.5"/>
+
+  <!-- Scanning animation hint — corner brackets around the face area -->
+  <!-- Top-left -->
+  <path d="M 108 285 L 108 270 Q 108 260, 118 260 L 133 260" fill="none" stroke="#10B981" stroke-width="3" stroke-linecap="round"/>
+  <!-- Top-right -->
+  <path d="M 268 285 L 268 270 Q 268 260, 258 260 L 243 260" fill="none" stroke="#10B981" stroke-width="3" stroke-linecap="round"/>
+  <!-- Bottom-left -->
+  <path d="M 108 495 L 108 510 Q 108 520, 118 520 L 133 520" fill="none" stroke="#10B981" stroke-width="3" stroke-linecap="round"/>
+  <!-- Bottom-right -->
+  <path d="M 268 495 L 268 510 Q 268 520, 258 520 L 243 520" fill="none" stroke="#10B981" stroke-width="3" stroke-linecap="round"/>
+
+  <!-- Instruction text below viewfinder -->
+  <text x="188" y="570" text-anchor="middle" font-family="Inter, sans-serif" font-size="15" font-weight="500" fill="#FFFFFF">Position your face in the frame</text>
+  <text x="188" y="592" text-anchor="middle" font-family="Inter, sans-serif" font-size="13" fill="#64748B">Look straight at the camera and hold still</text>
+
+  <!-- Why this is needed — trust explanation -->
+  <rect x="32" y="620" width="311" height="60" rx="12" fill="#1E293B" stroke="#334155" stroke-width="1"/>
+  <text x="56" y="645" font-family="Inter, sans-serif" font-size="20" fill="#F59E0B">&#x1F6E1;</text>
+  <text x="80" y="643" font-family="Inter, sans-serif" font-size="12" fill="#94A3B8">This check ensures only</text>
+  <text x="234" y="643" font-family="Inter, sans-serif" font-size="12" font-weight="600" fill="#FFFFFF">you</text>
+  <text x="248" y="643" font-family="Inter, sans-serif" font-size="12" fill="#94A3B8">can sign</text>
+  <text x="80" y="663" font-family="Inter, sans-serif" font-size="12" fill="#94A3B8">this high-value verification response.</text>
+
+  <!-- Cancel button -->
+  <rect x="32" y="704" width="311" height="44" rx="22" fill="none" stroke="#475569" stroke-width="1"/>
+  <text x="188" y="731" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" font-weight="500" fill="#94A3B8">Cancel</text>
+</svg>

--- a/design/wireframes/cachet-03b-liveness-failed.svg
+++ b/design/wireframes/cachet-03b-liveness-failed.svg
@@ -3,9 +3,20 @@
     SCREEN 3b (failure): Liveness Failed
     On the HOLDER's phone — the Veriff liveness check did not pass.
     Holder can retry or cancel. No KB-JWT was signed; nothing was shared.
+
+    Design tokens (from Color.kt):
+      BrandPrimaryDark    #0F172A   background
+      BrandPrimary        #1E293B   card bg, failure icon bg
+      BrandAccent         #10B981   completed step
+      BrandWarm           #F97068   failure step, failure icon X, cancel text
+      TrustRevokedBorder  #FCA5A5   failure step glow
+      TrustRevokedText    #B91C1C   failure icon border (dark coral)
+      SurfaceBorderDark   #334155   connectors, card border, pending step
+      TextSecondaryDark   #A8A29E   body text, tips
+      TextOnBrand         #FFFFFF   headings, step icons, button text
   -->
 
-  <!-- Phone background — dark -->
+  <!-- Phone background — BrandPrimaryDark -->
   <rect width="375" height="812" rx="40" fill="#0F172A"/>
 
   <!-- Status bar -->
@@ -13,43 +24,45 @@
   <circle cx="320" cy="48" r="4" fill="#10B981"/>
   <rect x="332" y="44" width="20" height="8" rx="2" fill="#FFFFFF"/>
 
-  <!-- Back arrow -->
-  <text x="30" y="95" font-family="Inter, sans-serif" font-size="20" fill="#94A3B8">&#x2190;</text>
+  <!-- Top bar: Back arrow (left) + Close X (right) -->
+  <text x="30" y="95" font-family="Inter, sans-serif" font-size="20" fill="#A8A29E">&#x2190;</text>
+  <text x="340" y="95" text-anchor="middle" font-family="Inter, sans-serif" font-size="18" font-weight="500" fill="#A8A29E">&#x2715;</text>
 
   <!-- Step indicator: Consent [done] > Liveness [failed] > Result [pending] -->
   <circle cx="148" cy="90" r="8" fill="#10B981"/>
   <text x="148" y="94" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="700" fill="#FFFFFF">&#x2713;</text>
   <line x1="156" y1="90" x2="181" y2="90" stroke="#334155" stroke-width="2"/>
-  <circle cx="188" cy="90" r="8" fill="#EF4444" stroke="#F87171" stroke-width="2"/>
+  <!-- Failed step: BrandWarm fill + TrustRevokedBorder glow -->
+  <circle cx="188" cy="90" r="8" fill="#F97068" stroke="#FCA5A5" stroke-width="2"/>
   <text x="188" y="94" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="700" fill="#FFFFFF">!</text>
   <line x1="196" y1="90" x2="221" y2="90" stroke="#334155" stroke-width="2"/>
   <circle cx="228" cy="90" r="8" fill="#334155"/>
 
-  <!-- Failure icon — large circle with X -->
-  <circle cx="188" cy="280" r="80" fill="#1E293B" stroke="#7F1D1D" stroke-width="2"/>
-  <circle cx="188" cy="280" r="60" fill="#450A0A" opacity="0.5"/>
-  <path d="M 168 260 L 208 300" stroke="#EF4444" stroke-width="5" stroke-linecap="round"/>
-  <path d="M 208 260 L 168 300" stroke="#EF4444" stroke-width="5" stroke-linecap="round"/>
+  <!-- Failure icon — large circle with X (BrandWarm palette) -->
+  <circle cx="188" cy="280" r="80" fill="#1E293B" stroke="#B91C1C" stroke-width="2"/>
+  <circle cx="188" cy="280" r="60" fill="#450A0A" opacity="0.3"/>
+  <path d="M 168 260 L 208 300" stroke="#F97068" stroke-width="5" stroke-linecap="round"/>
+  <path d="M 208 260 L 168 300" stroke="#F97068" stroke-width="5" stroke-linecap="round"/>
 
   <!-- Failure text -->
-  <text x="188" y="405" text-anchor="middle" font-family="Inter, sans-serif" font-size="22" font-weight="700" fill="#FFFFFF">We couldn't confirm it's you</text>
-  <text x="188" y="432" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" fill="#94A3B8">The identity check didn't pass.</text>
-  <text x="188" y="452" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" fill="#94A3B8">No credentials were shared.</text>
+  <text x="188" y="405" text-anchor="middle" font-family="Inter, sans-serif" font-size="22" font-weight="700" fill="#FFFFFF">We couldn&#x2019;t confirm it&#x2019;s you</text>
+  <text x="188" y="432" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" fill="#A8A29E">The identity check didn&#x2019;t pass.</text>
+  <text x="188" y="452" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" fill="#A8A29E">No credentials were shared.</text>
 
-  <!-- What to try -->
+  <!-- Tips card (BrandPrimary bg, SurfaceBorderDark stroke) -->
   <rect x="32" y="484" width="311" height="130" rx="16" fill="#1E293B" stroke="#334155" stroke-width="1"/>
   <text x="52" y="514" font-family="Inter, sans-serif" font-size="13" font-weight="600" fill="#FFFFFF">Tips for next time</text>
 
-  <text x="52" y="540" font-family="Inter, sans-serif" font-size="12" fill="#94A3B8">&#x2022;  Make sure your face is well-lit</text>
-  <text x="52" y="560" font-family="Inter, sans-serif" font-size="12" fill="#94A3B8">&#x2022;  Remove sunglasses or face coverings</text>
-  <text x="52" y="580" font-family="Inter, sans-serif" font-size="12" fill="#94A3B8">&#x2022;  Look straight at the camera, at eye level</text>
-  <text x="52" y="600" font-family="Inter, sans-serif" font-size="12" fill="#94A3B8">&#x2022;  Look as you did when you set up your ID</text>
+  <text x="52" y="540" font-family="Inter, sans-serif" font-size="12" fill="#A8A29E">&#x2022;  Make sure your face is well-lit</text>
+  <text x="52" y="560" font-family="Inter, sans-serif" font-size="12" fill="#A8A29E">&#x2022;  Remove sunglasses or face coverings</text>
+  <text x="52" y="580" font-family="Inter, sans-serif" font-size="12" fill="#A8A29E">&#x2022;  Look straight at the camera, at eye level</text>
+  <text x="52" y="600" font-family="Inter, sans-serif" font-size="12" fill="#A8A29E">&#x2022;  Look as you did when you set up your ID</text>
 
-  <!-- Retry button (primary) -->
+  <!-- Retry button — SealButton style (BrandAccent, 56dp height, 28dp radius) -->
   <rect x="32" y="648" width="311" height="56" rx="28" fill="#10B981"/>
   <text x="188" y="682" text-anchor="middle" font-family="Inter, sans-serif" font-size="16" font-weight="600" fill="#FFFFFF">Try Again</text>
 
-  <!-- Cancel button -->
+  <!-- Cancel button (BrandWarm text, no border) -->
   <rect x="32" y="716" width="311" height="44" rx="22" fill="none"/>
   <text x="188" y="743" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" font-weight="500" fill="#F97068">Cancel verification</text>
 </svg>

--- a/design/wireframes/cachet-03b-liveness-failed.svg
+++ b/design/wireframes/cachet-03b-liveness-failed.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 375 812" width="375" height="812">
+  <!--
+    SCREEN 3b (failure): Liveness Failed
+    On the HOLDER's phone — the Veriff liveness check did not pass.
+    Holder can retry or cancel. No KB-JWT was signed; nothing was shared.
+  -->
+
+  <!-- Phone background — dark -->
+  <rect width="375" height="812" rx="40" fill="#0F172A"/>
+
+  <!-- Status bar -->
+  <text x="30" y="52" font-family="Inter, sans-serif" font-size="14" font-weight="600" fill="#FFFFFF">9:41</text>
+  <circle cx="320" cy="48" r="4" fill="#10B981"/>
+  <rect x="332" y="44" width="20" height="8" rx="2" fill="#FFFFFF"/>
+
+  <!-- Back arrow -->
+  <text x="30" y="95" font-family="Inter, sans-serif" font-size="20" fill="#94A3B8">&#x2190;</text>
+
+  <!-- Step indicator: Consent [done] > Liveness [failed] > Result [pending] -->
+  <circle cx="148" cy="90" r="8" fill="#10B981"/>
+  <text x="148" y="94" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="700" fill="#FFFFFF">&#x2713;</text>
+  <line x1="156" y1="90" x2="181" y2="90" stroke="#334155" stroke-width="2"/>
+  <circle cx="188" cy="90" r="8" fill="#EF4444" stroke="#F87171" stroke-width="2"/>
+  <text x="188" y="94" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="700" fill="#FFFFFF">!</text>
+  <line x1="196" y1="90" x2="221" y2="90" stroke="#334155" stroke-width="2"/>
+  <circle cx="228" cy="90" r="8" fill="#334155"/>
+
+  <!-- Failure icon — large circle with X -->
+  <circle cx="188" cy="280" r="80" fill="#1E293B" stroke="#7F1D1D" stroke-width="2"/>
+  <circle cx="188" cy="280" r="60" fill="#450A0A" opacity="0.5"/>
+  <path d="M 168 260 L 208 300" stroke="#EF4444" stroke-width="5" stroke-linecap="round"/>
+  <path d="M 208 260 L 168 300" stroke="#EF4444" stroke-width="5" stroke-linecap="round"/>
+
+  <!-- Failure text -->
+  <text x="188" y="405" text-anchor="middle" font-family="Inter, sans-serif" font-size="22" font-weight="700" fill="#FFFFFF">We couldn't confirm it's you</text>
+  <text x="188" y="432" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" fill="#94A3B8">The identity check didn't pass.</text>
+  <text x="188" y="452" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" fill="#94A3B8">No credentials were shared.</text>
+
+  <!-- What to try -->
+  <rect x="32" y="484" width="311" height="130" rx="16" fill="#1E293B" stroke="#334155" stroke-width="1"/>
+  <text x="52" y="514" font-family="Inter, sans-serif" font-size="13" font-weight="600" fill="#FFFFFF">Tips for next time</text>
+
+  <text x="52" y="540" font-family="Inter, sans-serif" font-size="12" fill="#94A3B8">&#x2022;  Make sure your face is well-lit</text>
+  <text x="52" y="560" font-family="Inter, sans-serif" font-size="12" fill="#94A3B8">&#x2022;  Remove sunglasses or face coverings</text>
+  <text x="52" y="580" font-family="Inter, sans-serif" font-size="12" fill="#94A3B8">&#x2022;  Look straight at the camera, at eye level</text>
+  <text x="52" y="600" font-family="Inter, sans-serif" font-size="12" fill="#94A3B8">&#x2022;  Look as you did when you set up your ID</text>
+
+  <!-- Retry button (primary) -->
+  <rect x="32" y="648" width="311" height="56" rx="28" fill="#10B981"/>
+  <text x="188" y="682" text-anchor="middle" font-family="Inter, sans-serif" font-size="16" font-weight="600" fill="#FFFFFF">Try Again</text>
+
+  <!-- Cancel button -->
+  <rect x="32" y="716" width="311" height="44" rx="22" fill="none"/>
+  <text x="188" y="743" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" font-weight="500" fill="#F97068">Cancel verification</text>
+</svg>

--- a/devenv.nix
+++ b/devenv.nix
@@ -471,13 +471,10 @@ in
     ' _ {} \;
     echo "2. Checking emulator connection..."
     adb devices | grep device || (echo "❌ No Android emulator detected. Run 'android:emulator' first." && exit 1)
-    echo "3. Building and installing APKs..."
-    cd mobile && ./gradlew :androidApp:installDemoDebug :androidApp:installDemoDebugAndroidTest
-    echo "4. Running BDD tests via adb instrument..."
-    adb shell am instrument -w \
-      -e optionsAnnotationPackage id.cachet.wallet.android.bdd \
-      id.cachet.wallet.android.demo.test/id.cachet.wallet.android.bdd.CucumberTestRunner
+    echo "3. Running BDD tests..."
+    cd mobile && ./gradlew :androidApp:connectedDemoDebugAndroidTest
     echo "✅ BDD scenarios completed!"
+    echo "📊 Results: mobile/androidApp/build/reports/androidTests/"
   '';
   scripts."android:test-unit".exec = ''
     echo "🧪 Running unit tests..."

--- a/devenv.nix
+++ b/devenv.nix
@@ -30,6 +30,16 @@ in
     inherit prompt;
   }) allPlugins.agents;
   claude.code.mcpServers.devenv = mp.mcpServers.devenv;
+  claude.code.mcpServers.android = {
+    command = "${pkgs.uv}/bin/uv";
+    args = [
+      "run"
+      "--directory"
+      "/Users/hubertbehaghel/.local/share/android-mcp-server"
+      "server.py"
+    ];
+    type = "stdio";
+  };
 
   # Enable Veriff plugins for Claude Code (project-level settings.json is a Nix store symlink,
   # so /plugin install can't write to it — declare plugins here instead)
@@ -103,6 +113,7 @@ in
     jq
     openssl
     secretspec
+    uv  # Python package manager — needed for Android MCP server
   ];
 
   # Fixed port env vars — must match the PORT= values in process exec commands above

--- a/devenv.nix
+++ b/devenv.nix
@@ -471,10 +471,13 @@ in
     ' _ {} \;
     echo "2. Checking emulator connection..."
     adb devices | grep device || (echo "❌ No Android emulator detected. Run 'android:emulator' first." && exit 1)
-    echo "3. Running BDD tests..."
-    cd mobile && ./gradlew :androidApp:connectedDemoDebugAndroidTest
+    echo "3. Building and installing APKs..."
+    cd mobile && ./gradlew :androidApp:installDemoDebug :androidApp:installDemoDebugAndroidTest
+    echo "4. Running BDD tests via adb instrument..."
+    adb shell am instrument -w \
+      -e optionsAnnotationPackage id.cachet.wallet.android.bdd \
+      id.cachet.wallet.android.demo.test/id.cachet.wallet.android.bdd.CucumberTestRunner
     echo "✅ BDD scenarios completed!"
-    echo "📊 Results: mobile/androidApp/build/reports/androidTests/"
   '';
   scripts."android:test-unit".exec = ''
     echo "🧪 Running unit tests..."

--- a/devenv.nix
+++ b/devenv.nix
@@ -472,16 +472,16 @@ in
     echo "2. Checking emulator connection..."
     adb devices | grep device || (echo "❌ No Android emulator detected. Run 'android:emulator' first." && exit 1)
     echo "3. Running BDD tests..."
-    cd mobile && gradle :androidApp:connectedDemoDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=id.cachet.wallet.android.bdd.CucumberTestRunner
+    cd mobile && ./gradlew :androidApp:connectedDemoDebugAndroidTest
     echo "✅ BDD scenarios completed!"
     echo "📊 Results: mobile/androidApp/build/reports/androidTests/"
   '';
   scripts."android:test-unit".exec = ''
     echo "🧪 Running unit tests..."
     echo "1. Running shared module tests..."
-    cd mobile && gradle :shared:testDebugUnitTest
+    cd mobile && ./gradlew :shared:testDebugUnitTest
     echo "2. Running Android unit tests..."
-    gradle :androidApp:testDemoDebugUnitTest
+    ./gradlew :androidApp:testDemoDebugUnitTest
     echo "✅ Unit tests completed!"
     echo "📊 Test results available in mobile/*/build/reports/tests/"
   '';

--- a/docs/VERIFF_LIVENESS_RESEARCH.md
+++ b/docs/VERIFF_LIVENESS_RESEARCH.md
@@ -1,0 +1,197 @@
+# Veriff Liveness Detection — Research for #58
+
+**Date:** 2026-04-16
+**Purpose:** Evaluate Veriff's liveness capabilities for holder presence verification before KB-JWT signing.
+
+## Products Overview
+
+Veriff offers three biometric products — only one fits our use case cleanly:
+
+| Product | What it does | Our fit |
+|---------|-------------|---------|
+| **Biometric Liveness** | Stateless "is this a live person?" check. Single selfie, no stored template. | Not enough — proves liveness but not *which* person. |
+| **Biometric Authentication** | Matches a new selfie against a stored biometric template from a prior enrollment + liveness. | Best fit — proves the holder is the same person who enrolled during issuance. |
+| **Identity Verification** | Full document + selfie + liveness. | Already used at issuance time. Overkill for re-verification. |
+
+### Recommendation: Biometric Authentication
+
+Standalone liveness (product 1) only proves "a real human is present" — it doesn't prove it's *the same* human who holds the credential. Biometric Authentication (product 2) matches against the enrollment from the original Veriff identity verification session (which we already run during issuance). This gives us: **liveness + face match = proof the credential holder is physically present.**
+
+As of January 2026, Veriff added a **"Selfie-to-Selfie"** mode that can match against a prior selfie without full document re-enrollment, which simplifies integration.
+
+## Android SDK
+
+- **Current version:** 8.0.0 (March 2026)
+- **Dependency:** `implementation("com.veriff:veriff-library:$version")`
+- **Maven repo:** `https://cdn.veriff.me/android/`
+- **minSdkVersion:** 26 (Android 8.0+)
+- **Requires:** Kotlin 1.9.0+, AGP 7.2.0+, AndroidX
+- **Transitive deps of note:** ML Kit face detection, OkHttp 4.10, BouncyCastle 1.76, Compose BOM 2023.08
+
+### Permissions (auto-merged)
+
+Runtime: `CAMERA`, `RECORD_AUDIO`
+Auto-granted: `INTERNET`, `ACCESS_NETWORK_STATE`, `WAKE_LOCK`, `FOREGROUND_SERVICE`, `NFC`, `VIBRATE`
+
+All required — removing any causes crashes.
+
+### SDK Flow
+
+```
+1. Backend creates session → POST /v1/sessions → gets sessionUrl
+2. App launches SDK → Sdk.createLaunchIntent(activity, sessionUrl)
+3. SDK captures passive selfie (no user actions — no blinking/nodding)
+4. SDK submits images to Veriff servers automatically
+5. App receives SDK result: DONE | CANCELED | ERROR
+6. Actual decision arrives async via webhook to backend
+```
+
+Full branding customization available (colors, fonts, logo, 44+ languages).
+
+## API Integration
+
+### Session Creation
+
+```http
+POST /v1/sessions
+X-AUTH-CLIENT: [API-KEY]
+Content-Type: application/json
+
+{
+  "verification": {
+    "endUserId": "holder-uuid",
+    "vendorData": "session-correlation-id"
+  }
+}
+```
+
+Returns `verification.url` (for SDK) and `verification.id` (for tracking).
+
+### Decision Webhook
+
+```json
+{
+  "status": "success",
+  "verification": {
+    "id": "uuid",
+    "status": "approved",       // or "declined"
+    "code": 9001,               // 9001=approved, 9102=declined
+    "reason": null,             // human-readable on failure
+    "reasonCode": null,         // machine-readable on failure
+    "decisionTime": "ISO 8601"
+  }
+}
+```
+
+**Webhook security:** HMAC-SHA256 of raw body signed with shared secret (`x-hmac-signature` header). Must respond HTTP 200 within 5,000ms. At-least-once delivery.
+
+### Key Decline Reason Codes
+
+| Code | Meaning |
+|------|---------|
+| 105 | Suspicious behaviour |
+| 106 | Known fraud |
+| 503 | Attempted deceit |
+| 515 | Deceit via device screen |
+| 546 | Face image quality insufficient |
+| 547 | Face missing |
+
+### Session Lifecycle
+
+`created` → `started` → `submitted` → `approved` / `declined` / `expired` / `abandoned`
+
+## Anti-Spoofing Guarantees
+
+- **ISO/IEC 30107-3 Level 1 AND Level 2** PAD certified
+- Tested by **iBeta** (NIST/NVLAP-accredited lab), Level 2 achieved September 2024
+- **0% IAPAR** (Imposter Attack Presentation Accept Rate) — no Level 2 attacks succeeded
+
+Level 2 tests included:
+- 3D masks (resin, latex, silicone) costing up to $300
+- Realistic dolls
+- Deepfake videos
+- Attacks prepared over 2-4 days by moderately skilled attackers
+
+Multi-layered analysis: skin texture, facial contours, light reflections, device/emulator detection, virtual camera detection, behavioral signals.
+
+## Performance
+
+| Metric | Value |
+|--------|-------|
+| Liveness decision | Sub-second (fully automated) |
+| Biometric authentication | ~1 second |
+| Passive capture | Single selfie, no user actions |
+| Webhook timeout | 5,000ms acknowledgment required |
+
+## Offline Capability
+
+**None.** The SDK captures on-device but all decisions are server-side. ML Kit face detection is used only for on-device face framing/guidance during capture. Network connectivity is mandatory.
+
+This aligns with our existing architecture — the holder must be online to complete a verification flow anyway (relay communication, presentation submission).
+
+## Pricing
+
+Not publicly broken out for standalone products. Indicative ranges:
+
+| Volume | Per-session estimate |
+|--------|---------------------|
+| <500/month | $4–5 |
+| 500–5,000/month | $3–4 |
+| 5,000–20,000/month | $2.50–3.50 |
+| 20,000+/month | $2–3 (custom contract) |
+
+Biometric Authentication is an add-on with its own per-session fee. Multi-year commitments unlock 10-20% discounts.
+
+## Integration Plan for Cachet
+
+### What we already have
+
+- `VeriffService.kt` in `mobile/androidApp/` — wraps SDK launch, returns `VeriffResult(Success|Failure|Cancelled)`
+- `services/issuance-gateway/internal/veriff/` — handles Veriff webhooks with HMAC verification
+- Veriff identity verification sessions at issuance time create the **enrollment biometric template** we can match against
+
+### What we need
+
+1. **Backend: Liveness session endpoint** — the wallet requests a liveness session from our backend (not Veriff directly). Our backend creates the Veriff Biometric Authentication session, linking to the holder's original enrollment `endUserId`.
+
+2. **Backend: Liveness webhook handler** — receives the Veriff decision, stores pass/fail keyed to the verification session. The wallet polls or receives a push to learn the outcome.
+
+3. **Android: Liveness screen** — after consent, if CachPack requires liveness, launch the Veriff SDK. On `DONE`, wait for backend confirmation. On `CANCELED`/`ERROR`, show failure screen.
+
+4. **CachPack policy flag** — per-pack `requiresLiveness: true` configuration, checked before KB-JWT signing.
+
+5. **Gate KB-JWT signing** — `VerificationUseCase.respondViaRelay()` must check liveness result before calling `KBJWTBuilder.build()`.
+
+### Sequence: Consent → Liveness → Sign
+
+```
+Holder                    App                     Backend              Veriff
+  |                        |                        |                    |
+  |-- tap Verify & Share ->|                        |                    |
+  |                        |-- check pack policy -->|                    |
+  |                        |<- requiresLiveness ----|                    |
+  |                        |                        |                    |
+  |                        |-- POST /liveness ------>|                    |
+  |                        |                        |-- POST /v1/sessions ->|
+  |                        |                        |<-- sessionUrl --------|
+  |                        |<-- sessionUrl ---------|                    |
+  |                        |                        |                    |
+  |<-- launch Veriff SDK --|                        |                    |
+  |-- selfie captured ---->|--------- SDK submits images ------------->|
+  |                        |                        |                    |
+  |                        |                        |<--- webhook: approved/declined
+  |                        |<-- liveness passed ----|                    |
+  |                        |                        |                    |
+  |                        |-- sign KB-JWT -------->|                    |
+  |                        |-- send presentation -->|                    |
+  |<-- result screen ------|                        |                    |
+```
+
+### Open question
+
+Should we use **Biometric Liveness** (stateless, cheaper, just proves "live human") or **Biometric Authentication** (matches against enrollment, proves "same person")? The answer depends on threat model:
+
+- If the threat is *phone left unlocked on a table* → Biometric Authentication is needed (different person)
+- If the threat is *automated/bot attack on the signing endpoint* → Biometric Liveness suffices
+
+Given the issue #58 framing ("nobody else can use my phone to impersonate me"), **Biometric Authentication is the right choice** — it proves the person present is the credential holder, not just any live human.

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -19,6 +19,12 @@ android {
         // — runs both Cucumber .feature scenarios and regular JUnit4 instrumented tests
         testInstrumentationRunner = "id.cachet.wallet.android.bdd.CucumberTestRunner"
         testInstrumentationRunnerArguments["optionsAnnotationPackage"] = "id.cachet.wallet.android.bdd"
+
+        // Cucumber-Android reads .feature files via AssetManager.list() which
+        // fails if assets are compressed. Keep them uncompressed.
+        androidResources {
+            noCompress.add("feature")
+        }
         vectorDrawables {
             useSupportLibrary = true
         }

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/BddTestContext.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/BddTestContext.kt
@@ -1,8 +1,11 @@
 package id.cachet.wallet.android.bdd
 
 import android.content.Intent
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
@@ -28,6 +31,33 @@ class BddTestContext {
     companion object {
         @Volatile
         var sharedRule: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>? = null
+
+        /**
+         * After tapping "Verify & Share", handles the liveness gate if it appears,
+         * then waits for the verification result screen.
+         *
+         * High-value packs (Childcare, Seller, Identity) show a liveness screen;
+         * low-value packs (Age) skip straight to the result.
+         */
+        fun passLivenessIfNeeded(
+            rule: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>
+        ) {
+            rule.waitForIdle()
+            // Wait for either liveness or result screen to appear
+            rule.waitUntil(timeoutMillis = 10000) {
+                rule.onAllNodes(hasTestTag("liveness_check_screen")).fetchSemanticsNodes().isNotEmpty() ||
+                    rule.onAllNodes(hasTestTag("verification_result")).fetchSemanticsNodes().isNotEmpty()
+            }
+            // If liveness appeared, simulate pass
+            if (rule.onAllNodes(hasTestTag("liveness_check_screen")).fetchSemanticsNodes().isNotEmpty()) {
+                rule.onNodeWithText("Simulate Pass", substring = true).performClick()
+                rule.waitForIdle()
+            }
+            // Now wait for result screen
+            rule.waitUntil(timeoutMillis = 10000) {
+                rule.onAllNodes(hasTestTag("verification_result")).fetchSemanticsNodes().isNotEmpty()
+            }
+        }
     }
 
     /** The scenario name for the current BDD scenario. */

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/BddTestContext.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/BddTestContext.kt
@@ -2,7 +2,9 @@ package id.cachet.wallet.android.bdd
 
 import android.content.Intent
 import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -39,6 +41,25 @@ class BddTestContext {
          * High-value packs (Childcare, Seller, Identity) show a liveness screen;
          * low-value packs (Age) skip straight to the result.
          */
+        /**
+         * Taps the consent CTA — either "Verify with Face Scan" or "Verify & Share"
+         * depending on whether liveness is required.
+         */
+        fun tapConsentCta(
+            rule: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>
+        ) {
+            val faceScanNodes = rule.onAllNodesWithText("Verify with Face Scan").fetchSemanticsNodes()
+            val verifyShareNodes = rule.onAllNodesWithText("Verify & Share").fetchSemanticsNodes()
+            val btn = if (faceScanNodes.isNotEmpty()) {
+                rule.onNodeWithText("Verify with Face Scan")
+            } else {
+                rule.onNodeWithText("Verify & Share")
+            }
+            try { btn.performScrollTo() } catch (_: Throwable) {}
+            btn.performClick()
+            rule.waitForIdle()
+        }
+
         fun passLivenessIfNeeded(
             rule: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>
         ) {

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/BddTestContext.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/BddTestContext.kt
@@ -65,7 +65,8 @@ class BddTestContext {
         ) {
             rule.waitForIdle()
             // Wait for either liveness or result screen to appear
-            rule.waitUntil(timeoutMillis = 10000) {
+            // (deep-link flows after activity recreation may need extra time)
+            rule.waitUntil(timeoutMillis = 20000) {
                 rule.onAllNodes(hasTestTag("liveness_check_screen")).fetchSemanticsNodes().isNotEmpty() ||
                     rule.onAllNodes(hasTestTag("verification_result")).fetchSemanticsNodes().isNotEmpty()
             }
@@ -75,7 +76,7 @@ class BddTestContext {
                 rule.waitForIdle()
             }
             // Now wait for result screen
-            rule.waitUntil(timeoutMillis = 10000) {
+            rule.waitUntil(timeoutMillis = 20000) {
                 rule.onAllNodes(hasTestTag("verification_result")).fetchSemanticsNodes().isNotEmpty()
             }
         }

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/CommonSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/CommonSteps.kt
@@ -48,6 +48,8 @@ class CommonSteps {
     fun resetScenario() {
         DemoFixtures.isDemoActive = false
         DemoFixtures.activeScenario = ScenarioRegistry.get("happy")
+        DemoFixtures.overrideScanPack = null
+        DemoFixtures.livenessResult = DemoFixtures.LivenessResult.NONE
         InstrumentationRegistry.getInstrumentation().targetContext
             .getSharedPreferences("cachet_wallet", Context.MODE_PRIVATE)
             .edit().clear().apply()

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/CommonSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/CommonSteps.kt
@@ -17,6 +17,7 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import id.cachet.wallet.android.MainActivity
 import id.cachet.wallet.android.bdd.BddTestContext
+import id.cachet.wallet.android.ui.components.CachetType
 import id.cachet.wallet.android.ui.fixtures.DemoFixtures
 import id.cachet.wallet.android.ui.fixtures.ScenarioRegistry
 import io.cucumber.java.After
@@ -203,6 +204,10 @@ class CommonSteps {
             composeTestRule.onNodeWithText("Verification Request").assertIsDisplayed()
             return
         } catch (_: AssertionError) {}
+        // Use a low-value pack (no liveness) so "Verify & Share" appears for consent tests
+        if (DemoFixtures.overrideScanPack == null) {
+            DemoFixtures.overrideScanPack = DemoFixtures.cachPacks.first { it.cachetType == CachetType.AGE }
+        }
         // Navigate: Activity tab -> scan QR -> demo auto-scan -> incoming request
         composeTestRule.onNodeWithText("Activity").performClick()
         composeTestRule.waitForIdle()

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/CommonSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/CommonSteps.kt
@@ -248,7 +248,7 @@ class CommonSteps {
         composeTestRule.waitUntil(timeoutMillis = 5000) {
             composeTestRule.onAllNodes(hasTestTag("incoming_request_screen")).fetchSemanticsNodes().isNotEmpty()
         }
-        composeTestRule.onNodeWithText("Verify & Share").performClick()
+        BddTestContext.tapConsentCta(composeTestRule)
         BddTestContext.passLivenessIfNeeded(composeTestRule)
     }
 

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/CommonSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/CommonSteps.kt
@@ -249,10 +249,7 @@ class CommonSteps {
             composeTestRule.onAllNodes(hasTestTag("incoming_request_screen")).fetchSemanticsNodes().isNotEmpty()
         }
         composeTestRule.onNodeWithText("Verify & Share").performClick()
-        composeTestRule.waitForIdle()
-        composeTestRule.waitUntil(timeoutMillis = 10000) {
-            composeTestRule.onAllNodes(hasTestTag("verification_result")).fetchSemanticsNodes().isNotEmpty()
-        }
+        BddTestContext.passLivenessIfNeeded(composeTestRule)
     }
 
     @Given("the QR scanner is open")

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/DeepLinkVerifySteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/DeepLinkVerifySteps.kt
@@ -43,7 +43,7 @@ class DeepLinkVerifySteps {
         DemoFixtures.activeScenario = ScenarioRegistry.get("happy")
         rule.activityRule.scenario.recreate()
         rule.waitForIdle()
-        deliverDeepLink("cachet://verify?pack=childcare")
+        deliverDeepLink("cachet://verify?pack=age")
         rule.waitUntil(timeoutMillis = 5000) {
             rule.onAllNodesWithText("Verification Request").fetchSemanticsNodes().isNotEmpty()
         }

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/FirstLaunchSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/FirstLaunchSteps.kt
@@ -3,6 +3,7 @@ package id.cachet.wallet.android.bdd.steps
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import id.cachet.wallet.android.bdd.BddTestContext
@@ -88,6 +89,6 @@ class FirstLaunchSteps {
 
     @Then("the step indicator shows {string}")
     fun theStepIndicatorShows(progress: String) {
-        rule.onNodeWithText(progress, substring = true).assertIsDisplayed()
+        rule.onNodeWithContentDescription(progress, substring = true).assertIsDisplayed()
     }
 }

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/LivenessSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/LivenessSteps.kt
@@ -1,0 +1,202 @@
+package id.cachet.wallet.android.bdd.steps
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import id.cachet.wallet.android.bdd.BddTestContext
+import id.cachet.wallet.android.ui.fixtures.DemoFixtures
+import id.cachet.wallet.android.ui.mapper.CachPackMapper
+import io.cucumber.java.en.Given
+import io.cucumber.java.en.Then
+import io.cucumber.java.en.When
+
+/**
+ * Step definitions for the liveness-before-signing story.
+ *
+ * Covers: per-pack consent routing, liveness gate, liveness pass/fail,
+ * and cancel flows.
+ */
+class LivenessSteps {
+
+    private val rule get() = BddTestContext.sharedRule!!
+
+    // ────────────────────────────────────────
+    // Given: Navigate to Incoming Request for a specific pack
+    // ────────────────────────────────────────
+
+    @Given("I am on the Incoming Request screen for a {string} pack")
+    fun iAmOnTheIncomingRequestScreenForPack(packName: String) {
+        val pack = DemoFixtures.cachPacks.firstOrNull { packDisplayName(it) == packName }
+            ?: error("Unknown pack: $packName. Available: ${DemoFixtures.cachPacks.map { packDisplayName(it) }}")
+
+        // Set this pack as the demo scan target
+        DemoFixtures.overrideScanPack = pack
+
+        // Navigate: Activity tab -> scan QR -> demo auto-scan -> incoming request
+        rule.onNodeWithText("Activity").performClick()
+        rule.waitForIdle()
+        rule.onNodeWithTag("fab_scan_qr").performClick()
+        rule.waitForIdle()
+        rule.waitUntil(timeoutMillis = 5000) {
+            rule.onAllNodesWithTag("incoming_request_screen").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Verify we see the right pack's question
+        val expectedQuestion = CachPackMapper.toVerificationRequest(pack).question
+        rule.onNodeWithText(expectedQuestion).assertIsDisplayed()
+    }
+
+    @Given("I hold a valid credential")
+    fun iHoldAValidCredential() {
+        // In demo mode with happy scenario, we already have credentials — no-op
+    }
+
+    // ────────────────────────────────────────
+    // Then: Liveness skipped (straight to result)
+    // ────────────────────────────────────────
+
+    @Then("the verification is performed without a liveness check")
+    fun theVerificationIsPerformedWithoutALivenessCheck() {
+        // Tap "Verify & Share" and expect result screen directly (no liveness screen in between)
+        rule.onNodeWithText("Verify & Share").performClick()
+        rule.waitForIdle()
+
+        // Should NOT see liveness screen
+        val livenessNodes = rule.onAllNodesWithTag("liveness_check_screen").fetchSemanticsNodes()
+        assert(livenessNodes.isEmpty()) { "Expected NO liveness screen for low-value pack, but found one" }
+
+        // Should see result screen
+        rule.waitUntil(timeoutMillis = 10000) {
+            rule.onAllNodesWithTag("verification_result").fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Then("I see the Verification Result screen")
+    fun iSeeTheVerificationResultScreen() {
+        rule.onNodeWithTag("verification_result").assertIsDisplayed()
+    }
+
+    // ────────────────────────────────────────
+    // Then: Liveness gate (screen appears)
+    // ────────────────────────────────────────
+
+    @Then("I see the Liveness Check screen")
+    fun iSeeTheLivenessCheckScreen() {
+        rule.waitUntil(timeoutMillis = 5000) {
+            rule.onAllNodesWithTag("liveness_check_screen").fetchSemanticsNodes().isNotEmpty()
+        }
+        rule.onNodeWithTag("liveness_check_screen").assertIsDisplayed()
+    }
+
+    @Then("the screen explains why liveness is needed")
+    fun theScreenExplainsWhyLivenessIsNeeded() {
+        rule.onNodeWithText("Prove it's you", substring = true).assertIsDisplayed()
+    }
+
+    @Then("the front camera activates for the Veriff liveness session")
+    fun theFrontCameraActivatesForVeriffSession() {
+        // In demo mode we show a camera placeholder, not a real Veriff SDK
+        rule.onNodeWithTag("liveness_camera_area").assertIsDisplayed()
+    }
+
+    // ────────────────────────────────────────
+    // Given: Already on Liveness Check screen
+    // ────────────────────────────────────────
+
+    @Given("I am on the Liveness Check screen")
+    fun iAmOnTheLivenessCheckScreen() {
+        // Navigate to incoming request for a high-value pack, then tap Verify & Share
+        iAmOnTheIncomingRequestScreenForPack("Childcare Readiness")
+        rule.onNodeWithText("Verify & Share").performClick()
+        rule.waitForIdle()
+        rule.waitUntil(timeoutMillis = 5000) {
+            rule.onAllNodesWithTag("liveness_check_screen").fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    // ────────────────────────────────────────
+    // When/Then: Liveness outcomes
+    // ────────────────────────────────────────
+
+    @When("the Veriff liveness check succeeds")
+    fun theVeriffLivenessCheckSucceeds() {
+        // In demo mode, tap "Simulate Pass" or auto-proceed
+        DemoFixtures.livenessResult = DemoFixtures.LivenessResult.PASS
+        rule.onNodeWithText("Simulate Pass", substring = true).performClick()
+        rule.waitForIdle()
+    }
+
+    @When("the Veriff liveness check fails")
+    fun theVeriffLivenessCheckFails() {
+        // In demo mode, tap "Simulate Fail"
+        DemoFixtures.livenessResult = DemoFixtures.LivenessResult.FAIL
+        rule.onNodeWithText("Simulate Fail", substring = true).performClick()
+        rule.waitForIdle()
+    }
+
+    @Then("the KB-JWT is signed and the presentation is sent")
+    fun theKBJWTIsSignedAndPresentationSent() {
+        // In demo mode, just verify we reach the result screen
+        rule.waitUntil(timeoutMillis = 10000) {
+            rule.onAllNodesWithTag("verification_result").fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Then("the KB-JWT is not signed")
+    fun theKBJWTIsNotSigned() {
+        // Verify we did NOT reach the result screen
+        val resultNodes = rule.onAllNodesWithTag("verification_result").fetchSemanticsNodes()
+        assert(resultNodes.isEmpty()) { "Expected no verification result, but KB-JWT was signed" }
+    }
+
+    @Then("I see a liveness failure message")
+    fun iSeeALivenessFailureMessage() {
+        rule.onNodeWithText("couldn't confirm", substring = true).assertIsDisplayed()
+    }
+
+    @Then("I can retry the liveness check or cancel")
+    fun iCanRetryOrCancel() {
+        rule.onNodeWithText("Try Again").assertIsDisplayed()
+        rule.onNodeWithText("Cancel", substring = true).assertIsDisplayed()
+    }
+
+    @Then("I return to the Incoming Request screen")
+    fun iReturnToTheIncomingRequestScreen() {
+        rule.waitUntil(timeoutMillis = 5000) {
+            rule.onAllNodesWithTag("incoming_request_screen").fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Then("no credentials are shared")
+    fun noCredentialsAreShared() {
+        // Verify we're NOT on the result screen
+        val resultNodes = rule.onAllNodesWithTag("verification_result").fetchSemanticsNodes()
+        assert(resultNodes.isEmpty()) { "Credentials were shared when they should not have been" }
+    }
+
+    @Then("the verification completes without liveness")
+    fun theVerificationCompletesWithoutLiveness() {
+        // "Verify & Share" was already tapped by a prior When step.
+        // Just assert: no liveness screen appeared, and result screen is visible.
+        rule.waitForIdle()
+        val livenessNodes = rule.onAllNodesWithTag("liveness_check_screen").fetchSemanticsNodes()
+        assert(livenessNodes.isEmpty()) { "Expected NO liveness screen for low-value pack" }
+        rule.waitUntil(timeoutMillis = 10000) {
+            rule.onAllNodesWithTag("verification_result").fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    // ────────────────────────────────────────
+    // Helpers
+    // ────────────────────────────────────────
+
+    private fun packDisplayName(pack: id.cachet.wallet.android.ui.model.CachPackUi): String =
+        when (pack.cachetType) {
+            id.cachet.wallet.android.ui.components.CachetType.CHILDCARE -> "Childcare Readiness"
+            id.cachet.wallet.android.ui.components.CachetType.SELLER -> "Safe Seller"
+            id.cachet.wallet.android.ui.components.CachetType.AGE -> "Age Verification"
+            id.cachet.wallet.android.ui.components.CachetType.IDENTITY -> "Identity Verification"
+        }
+}

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/LivenessSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/LivenessSteps.kt
@@ -57,7 +57,9 @@ class LivenessSteps {
 
     @Then("the action button reads {string}")
     fun theActionButtonReads(expectedText: String) {
-        rule.onNodeWithText(expectedText).assertIsDisplayed()
+        val node = rule.onNodeWithText(expectedText)
+        try { node.performScrollTo() } catch (_: Throwable) {}
+        node.assertIsDisplayed()
     }
 
     @Given("I hold a valid credential")
@@ -177,7 +179,8 @@ class LivenessSteps {
 
     @Then("I return to the Incoming Request screen")
     fun iReturnToTheIncomingRequestScreen() {
-        rule.waitUntil(timeoutMillis = 5000) {
+        rule.waitForIdle()
+        rule.waitUntil(timeoutMillis = 10000) {
             rule.onAllNodesWithTag("incoming_request_screen").fetchSemanticsNodes().isNotEmpty()
         }
     }

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/LivenessSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/LivenessSteps.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import id.cachet.wallet.android.bdd.BddTestContext
 import id.cachet.wallet.android.ui.fixtures.DemoFixtures
 import id.cachet.wallet.android.ui.mapper.CachPackMapper
@@ -26,7 +27,7 @@ class LivenessSteps {
     // Given: Navigate to Incoming Request for a specific pack
     // ────────────────────────────────────────
 
-    @Given("I am on the Incoming Request screen for a {string} pack")
+    @Given("I am on the Incoming Request screen for a/an {string} pack")
     fun iAmOnTheIncomingRequestScreenForPack(packName: String) {
         val pack = DemoFixtures.cachPacks.firstOrNull { packDisplayName(it) == packName }
             ?: error("Unknown pack: $packName. Available: ${DemoFixtures.cachPacks.map { packDisplayName(it) }}")
@@ -60,7 +61,9 @@ class LivenessSteps {
     @Then("the verification is performed without a liveness check")
     fun theVerificationIsPerformedWithoutALivenessCheck() {
         // Tap "Verify & Share" and expect result screen directly (no liveness screen in between)
-        rule.onNodeWithText("Verify & Share").performClick()
+        val verifyBtn = rule.onNodeWithText("Verify & Share")
+        try { verifyBtn.performScrollTo() } catch (_: Throwable) {}
+        verifyBtn.performClick()
         rule.waitForIdle()
 
         // Should NOT see liveness screen
@@ -92,7 +95,7 @@ class LivenessSteps {
 
     @Then("the screen explains why liveness is needed")
     fun theScreenExplainsWhyLivenessIsNeeded() {
-        rule.onNodeWithText("Prove it's you", substring = true).assertIsDisplayed()
+        rule.onNodeWithText("Prove it\u2019s you", substring = true).assertIsDisplayed()
     }
 
     @Then("the front camera activates for the Veriff liveness session")
@@ -109,7 +112,9 @@ class LivenessSteps {
     fun iAmOnTheLivenessCheckScreen() {
         // Navigate to incoming request for a high-value pack, then tap Verify & Share
         iAmOnTheIncomingRequestScreenForPack("Childcare Readiness")
-        rule.onNodeWithText("Verify & Share").performClick()
+        val verifyBtn = rule.onNodeWithText("Verify & Share")
+        try { verifyBtn.performScrollTo() } catch (_: Throwable) {}
+        verifyBtn.performClick()
         rule.waitForIdle()
         rule.waitUntil(timeoutMillis = 5000) {
             rule.onAllNodesWithTag("liveness_check_screen").fetchSemanticsNodes().isNotEmpty()
@@ -153,13 +158,15 @@ class LivenessSteps {
 
     @Then("I see a liveness failure message")
     fun iSeeALivenessFailureMessage() {
-        rule.onNodeWithText("couldn't confirm", substring = true).assertIsDisplayed()
+        rule.onNodeWithText("couldn\u2019t confirm", substring = true).assertIsDisplayed()
     }
 
     @Then("I can retry the liveness check or cancel")
     fun iCanRetryOrCancel() {
         rule.onNodeWithText("Try Again").assertIsDisplayed()
-        rule.onNodeWithText("Cancel", substring = true).assertIsDisplayed()
+        val cancelNode = rule.onNodeWithText("Cancel", substring = true)
+        try { cancelNode.performScrollTo() } catch (_: Throwable) {}
+        cancelNode.assertIsDisplayed()
     }
 
     @Then("I return to the Incoming Request screen")

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/LivenessSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/LivenessSteps.kt
@@ -49,6 +49,17 @@ class LivenessSteps {
         rule.onNodeWithText(expectedQuestion).assertIsDisplayed()
     }
 
+    @Then("I see a face scan notice")
+    fun iSeeAFaceScanNotice() {
+        rule.onNodeWithTag("biometric_notice").assertIsDisplayed()
+        rule.onNodeWithText("face scan", substring = true).assertIsDisplayed()
+    }
+
+    @Then("the action button reads {string}")
+    fun theActionButtonReads(expectedText: String) {
+        rule.onNodeWithText(expectedText).assertIsDisplayed()
+    }
+
     @Given("I hold a valid credential")
     fun iHoldAValidCredential() {
         // In demo mode with happy scenario, we already have credentials — no-op
@@ -61,9 +72,7 @@ class LivenessSteps {
     @Then("the verification is performed without a liveness check")
     fun theVerificationIsPerformedWithoutALivenessCheck() {
         // Tap "Verify & Share" and expect result screen directly (no liveness screen in between)
-        val verifyBtn = rule.onNodeWithText("Verify & Share")
-        try { verifyBtn.performScrollTo() } catch (_: Throwable) {}
-        verifyBtn.performClick()
+        BddTestContext.tapConsentCta(rule)
         rule.waitForIdle()
 
         // Should NOT see liveness screen
@@ -112,10 +121,7 @@ class LivenessSteps {
     fun iAmOnTheLivenessCheckScreen() {
         // Navigate to incoming request for a high-value pack, then tap Verify & Share
         iAmOnTheIncomingRequestScreenForPack("Childcare Readiness")
-        val verifyBtn = rule.onNodeWithText("Verify & Share")
-        try { verifyBtn.performScrollTo() } catch (_: Throwable) {}
-        verifyBtn.performClick()
-        rule.waitForIdle()
+        BddTestContext.tapConsentCta(rule)
         rule.waitUntil(timeoutMillis = 5000) {
             rule.onAllNodesWithTag("liveness_check_screen").fetchSemanticsNodes().isNotEmpty()
         }

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/ScanToVerifySteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/ScanToVerifySteps.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import id.cachet.wallet.android.bdd.BddTestContext
+import id.cachet.wallet.android.bdd.BddTestContext.Companion.passLivenessIfNeeded
 import io.cucumber.java.en.Given
 import io.cucumber.java.en.Then
 import io.cucumber.java.en.When
@@ -101,9 +102,7 @@ class ScanToVerifySteps {
     // AC-5: Consent decision
     @Then("the verification is performed and I see the Verification Result screen")
     fun theVerificationIsPerformedAndISeeTheResult() {
-        rule.waitUntil(timeoutMillis = 10000) {
-            rule.onAllNodes(hasTestTag("verification_result")).fetchSemanticsNodes().isNotEmpty()
-        }
+        BddTestContext.passLivenessIfNeeded(rule)
         rule.onNodeWithTag("verification_result").assertIsDisplayed()
     }
 

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/VerificationResultSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/VerificationResultSteps.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import id.cachet.wallet.android.bdd.BddTestContext
+import id.cachet.wallet.android.bdd.BddTestContext.Companion.passLivenessIfNeeded
 import id.cachet.wallet.android.ui.fixtures.DemoFixtures
 import id.cachet.wallet.android.ui.fixtures.ScenarioRegistry
 import io.cucumber.java.en.Given
@@ -44,10 +45,7 @@ class VerificationResultSteps {
             rule.onAllNodes(hasTestTag("incoming_request_screen")).fetchSemanticsNodes().isNotEmpty()
         }
         rule.onNodeWithText("Verify & Share").performClick()
-        rule.waitForIdle()
-        rule.waitUntil(timeoutMillis = 10000) {
-            rule.onAllNodes(hasTestTag("verification_result")).fetchSemanticsNodes().isNotEmpty()
-        }
+        BddTestContext.passLivenessIfNeeded(rule)
     }
 
     @Given("a verification has completed")
@@ -122,10 +120,7 @@ class VerificationResultSteps {
             rule.onAllNodes(hasTestTag("incoming_request_screen")).fetchSemanticsNodes().isNotEmpty()
         }
         rule.onNodeWithText("Verify & Share").performClick()
-        rule.waitForIdle()
-        rule.waitUntil(timeoutMillis = 10000) {
-            rule.onAllNodes(hasTestTag("verification_result")).fetchSemanticsNodes().isNotEmpty()
-        }
+        BddTestContext.passLivenessIfNeeded(rule)
     }
 
     @Then("I see a {word} result for {string}")

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/VerificationResultSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/VerificationResultSteps.kt
@@ -33,6 +33,7 @@ class VerificationResultSteps {
         val scenario = if (outcome == "pass") "happy" else "seller-only"
         DemoFixtures.isDemoActive = true
         DemoFixtures.activeScenario = ScenarioRegistry.get(scenario)
+        rule.waitForIdle()
         rule.activityRule.scenario.recreate()
         rule.waitForIdle()
 
@@ -65,7 +66,8 @@ class VerificationResultSteps {
 
     @Then("I see a clear reason for the failure")
     fun iSeeAClearReasonForTheFailure() {
-        rule.onAllNodesWithText("Credential not available", substring = true).onFirst().assertExists()
+        // Seller-only scenario shows seller-specific fail reasons
+        rule.onAllNodesWithText("below threshold", substring = true).onFirst().assertExists()
     }
 
     // AC-3: Individual predicate results
@@ -135,6 +137,6 @@ class VerificationResultSteps {
 
     @Then("I see which seller predicates failed")
     fun iSeeWhichSellerPredicatesFailed() {
-        rule.onAllNodesWithText("Credential not available", substring = true).onFirst().assertExists()
+        rule.onAllNodesWithText("below threshold", substring = true).onFirst().assertExists()
     }
 }

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/VerificationResultSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/VerificationResultSteps.kt
@@ -44,7 +44,7 @@ class VerificationResultSteps {
         rule.waitUntil(timeoutMillis = 5000) {
             rule.onAllNodes(hasTestTag("incoming_request_screen")).fetchSemanticsNodes().isNotEmpty()
         }
-        rule.onNodeWithText("Verify & Share").performClick()
+        BddTestContext.tapConsentCta(rule)
         BddTestContext.passLivenessIfNeeded(rule)
     }
 
@@ -119,7 +119,7 @@ class VerificationResultSteps {
         rule.waitUntil(timeoutMillis = 5000) {
             rule.onAllNodes(hasTestTag("incoming_request_screen")).fetchSemanticsNodes().isNotEmpty()
         }
-        rule.onNodeWithText("Verify & Share").performClick()
+        BddTestContext.tapConsentCta(rule)
         BddTestContext.passLivenessIfNeeded(rule)
     }
 

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/VerifierRequestSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/VerifierRequestSteps.kt
@@ -81,9 +81,7 @@ class VerifierRequestSteps {
             rule.onAllNodes(hasTestTag("incoming_request_screen")).fetchSemanticsNodes().isNotEmpty()
         }
         // Simulate the holder accepting and completing the flow
-        val verifyBtn = rule.onNodeWithText("Verify & Share")
-        try { verifyBtn.performScrollTo() } catch (_: Throwable) {}
-        verifyBtn.performClick()
+        BddTestContext.tapConsentCta(rule)
         passLivenessIfNeeded(rule)
     }
 

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/VerifierRequestSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/VerifierRequestSteps.kt
@@ -1,12 +1,15 @@
 package id.cachet.wallet.android.bdd.steps
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import id.cachet.wallet.android.bdd.BddTestContext
+import id.cachet.wallet.android.bdd.BddTestContext.Companion.passLivenessIfNeeded
 import io.cucumber.java.en.Given
 import io.cucumber.java.en.Then
 import io.cucumber.java.en.When
@@ -73,9 +76,15 @@ class VerifierRequestSteps {
 
     @When("a holder scans and completes the verification")
     fun aHolderScansAndCompletesTheVerification() {
-        // In demo mode, the flow auto-transitions after a delay
-        Thread.sleep(5000) // Wait for demo auto-transition
-        rule.waitForIdle()
+        // In demo mode, the QR share screen auto-transitions to IncomingRequest after ~4s
+        rule.waitUntil(timeoutMillis = 10000) {
+            rule.onAllNodes(hasTestTag("incoming_request_screen")).fetchSemanticsNodes().isNotEmpty()
+        }
+        // Simulate the holder accepting and completing the flow
+        val verifyBtn = rule.onNodeWithText("Verify & Share")
+        try { verifyBtn.performScrollTo() } catch (_: Throwable) {}
+        verifyBtn.performClick()
+        passLivenessIfNeeded(rule)
     }
 
     @Then("the session status updates")

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/VerifierRequestSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/VerifierRequestSteps.kt
@@ -83,8 +83,4 @@ class VerifierRequestSteps {
         rule.waitForIdle()
     }
 
-    @Then("I see the Verification Result screen")
-    fun iSeeTheVerificationResultScreen() {
-        rule.waitForIdle()
-    }
 }

--- a/mobile/androidApp/src/demo/kotlin/id/cachet/wallet/android/ui/fixtures/DemoFixtures.kt
+++ b/mobile/androidApp/src/demo/kotlin/id/cachet/wallet/android/ui/fixtures/DemoFixtures.kt
@@ -23,6 +23,15 @@ object DemoFixtures {
     /** The active scenario. Set once during app init before any composable reads it. */
     var activeScenario: DemoScenario = HappyPathScenario
 
+    /** Override which pack the QR scanner demo uses. null = use scenario default. */
+    @Volatile
+    var overrideScanPack: CachPackUi? = null
+
+    /** Liveness result for demo mode. Set by BDD tests before triggering liveness. */
+    enum class LivenessResult { PASS, FAIL, NONE }
+    @Volatile
+    var livenessResult: LivenessResult = LivenessResult.NONE
+
     /** Synthetic credential for consent receipt generation when no real credential is in the repo. */
     val syntheticCredential = VerifiableCredential(
         id = "urn:demo:synthetic",
@@ -57,6 +66,18 @@ object DemoFixtures {
     /** Delegate pass/fail decision to the active scenario. */
     fun shouldPass(request: VerificationRequest): Boolean =
         activeScenario.shouldPass(request)
+
+    /** The pack to use for the next QR demo scan (override or scenario default). */
+    val effectiveScanPack: CachPackUi
+        get() = overrideScanPack ?: activeScenario.defaultScanPack
+
+    /** Per-CachPack liveness policy: high-value packs require liveness, low-value skip. */
+    fun requiresLiveness(type: CachetType): Boolean = when (type) {
+        CachetType.CHILDCARE -> true
+        CachetType.SELLER -> true
+        CachetType.IDENTITY -> true
+        CachetType.AGE -> false
+    }
 
     // -- Static overlay fixtures (not scenario-dependent) --
 

--- a/mobile/androidApp/src/demo/kotlin/id/cachet/wallet/android/ui/fixtures/HappyPathScenario.kt
+++ b/mobile/androidApp/src/demo/kotlin/id/cachet/wallet/android/ui/fixtures/HappyPathScenario.kt
@@ -53,7 +53,8 @@ object HappyPathScenario : DemoScenario {
     override val cachPacks = listOf(
         CachPackUi(id = PackIds.CHILDCARE_ES, question = "Safe for my kids?", description = "Identity, background check, references", proofCount = 4, cachetType = CachetType.CHILDCARE),
         CachPackUi(id = PackIds.SAFE_SELLER, question = "Trusted seller?", description = "Identity, platform history, fulfilment rate", proofCount = 4, cachetType = CachetType.SELLER),
-        CachPackUi(id = PackIds.CHILDCARE_BASE, question = "Old enough?", description = "Age verification (18+ or 21+)", proofCount = 1, cachetType = CachetType.AGE)
+        CachPackUi(id = PackIds.CHILDCARE_BASE, question = "Old enough?", description = "Age verification (18+ or 21+)", proofCount = 1, cachetType = CachetType.AGE),
+        CachPackUi(id = PackIds.IDENTITY_BASIC, question = "Who are you?", description = "Identity verification, liveness", proofCount = 2, cachetType = CachetType.IDENTITY)
     )
 
     override val historyGroups = listOf(

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/WalletApp.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/WalletApp.kt
@@ -231,32 +231,34 @@ fun WalletApp(demoMode: Boolean = false, demoEmpty: Boolean = false, demoScenari
                     }
                 )
             }
-            is OverlayScreen.IncomingRequest -> IncomingRequestScreen(
-                request = screen.request,
-                onShare = {
-                    // Liveness gate: high-value packs require identity confirmation
-                    val needsLiveness = effectiveDemoMode &&
-                        DemoFixtures.requiresLiveness(screen.request.cachetType)
-                    if (needsLiveness) {
-                        overlay = OverlayScreen.LivenessCheck(screen.request)
-                    } else {
-                        scope.launch {
-                            if (qrPayload.startsWith("cachet://") && !effectiveDemoMode) {
-                                viewModel.holderRespondViaRelay(qrPayload)
-                                val result = viewModel.awaitVerifierResult()
-                                overlay = OverlayScreen.CachetResultOverlay(result)
-                                qrPayload = ""
-                            } else {
-                                val result = viewModel.shareCredential(screen.request)
-                                overlay = OverlayScreen.CachetResultOverlay(result)
-                                qrPayload = ""
+            is OverlayScreen.IncomingRequest -> {
+                val needsLiveness = effectiveDemoMode &&
+                    DemoFixtures.requiresLiveness(screen.request.cachetType)
+                IncomingRequestScreen(
+                    request = screen.request,
+                    requiresLiveness = needsLiveness,
+                    onShare = {
+                        if (needsLiveness) {
+                            overlay = OverlayScreen.LivenessCheck(screen.request)
+                        } else {
+                            scope.launch {
+                                if (qrPayload.startsWith("cachet://") && !effectiveDemoMode) {
+                                    viewModel.holderRespondViaRelay(qrPayload)
+                                    val result = viewModel.awaitVerifierResult()
+                                    overlay = OverlayScreen.CachetResultOverlay(result)
+                                    qrPayload = ""
+                                } else {
+                                    val result = viewModel.shareCredential(screen.request)
+                                    overlay = OverlayScreen.CachetResultOverlay(result)
+                                    qrPayload = ""
+                                }
                             }
                         }
-                    }
-                },
-                onDecline = { overlay = null; qrPayload = "" },
-                onClose = { overlay = null; qrPayload = "" }
-            )
+                    },
+                    onDecline = { overlay = null; qrPayload = "" },
+                    onClose = { overlay = null; qrPayload = "" }
+                )
+            }
             is OverlayScreen.LivenessCheck -> {
                 val packName = CachPackMapper.cachetDisplayName(screen.request.cachetType)
                 LivenessCheckScreen(

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/WalletApp.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/WalletApp.kt
@@ -27,6 +27,8 @@ import id.cachet.wallet.android.ui.theme.*
 import id.cachet.wallet.android.ui.verification.CachetResultScreen
 import id.cachet.wallet.android.ui.verification.DeepLinkExpiredScreen
 import id.cachet.wallet.android.ui.verification.IncomingRequestScreen
+import id.cachet.wallet.android.ui.verification.LivenessCheckScreen
+import id.cachet.wallet.android.ui.verification.LivenessFailedScreen
 import id.cachet.wallet.android.ui.verification.PackPickerMode
 import id.cachet.wallet.android.ui.verification.PackPickerScreen
 import id.cachet.wallet.android.ui.verification.QrScannerScreen
@@ -60,6 +62,8 @@ sealed class OverlayScreen {
         val pack: CachPackUi
     ) : OverlayScreen()
     data class IncomingRequest(val request: VerificationRequest) : OverlayScreen()
+    data class LivenessCheck(val request: VerificationRequest) : OverlayScreen()
+    data class LivenessFailed(val request: VerificationRequest) : OverlayScreen()
     data class CachetResultOverlay(val result: CachetResult) : OverlayScreen()
     data class CachetDetail(val detail: CachetDetailUi) : OverlayScreen()
     data object QrScanner : OverlayScreen()
@@ -162,10 +166,11 @@ fun WalletApp(demoMode: Boolean = false, demoEmpty: Boolean = false, demoScenari
                     if (relayQr == null) {
                         // Relay unavailable -- fall back to demo auto-transition
                         if (effectiveDemoMode) {
-                            qrPayload = packToQrPayload(screen.pack)
+                            val effectivePack = DemoFixtures.overrideScanPack ?: screen.pack
+                            qrPayload = packToQrPayload(effectivePack)
                             kotlinx.coroutines.delay(4000)
                             overlay = OverlayScreen.IncomingRequest(
-                                CachPackMapper.toVerificationRequest(screen.pack)
+                                CachPackMapper.toVerificationRequest(effectivePack)
                             )
                             return@LaunchedEffect
                         }
@@ -229,21 +234,56 @@ fun WalletApp(demoMode: Boolean = false, demoEmpty: Boolean = false, demoScenari
             is OverlayScreen.IncomingRequest -> IncomingRequestScreen(
                 request = screen.request,
                 onShare = {
-                    scope.launch {
-                        if (qrPayload.startsWith("cachet://") && !effectiveDemoMode) {
-                            viewModel.holderRespondViaRelay(qrPayload)
-                            val result = viewModel.awaitVerifierResult()
-                            overlay = OverlayScreen.CachetResultOverlay(result)
-                            qrPayload = ""
-                        } else {
-                            val result = viewModel.shareCredential(screen.request)
-                            overlay = OverlayScreen.CachetResultOverlay(result)
-                            qrPayload = ""
+                    // Liveness gate: high-value packs require identity confirmation
+                    val needsLiveness = effectiveDemoMode &&
+                        DemoFixtures.requiresLiveness(screen.request.cachetType)
+                    if (needsLiveness) {
+                        overlay = OverlayScreen.LivenessCheck(screen.request)
+                    } else {
+                        scope.launch {
+                            if (qrPayload.startsWith("cachet://") && !effectiveDemoMode) {
+                                viewModel.holderRespondViaRelay(qrPayload)
+                                val result = viewModel.awaitVerifierResult()
+                                overlay = OverlayScreen.CachetResultOverlay(result)
+                                qrPayload = ""
+                            } else {
+                                val result = viewModel.shareCredential(screen.request)
+                                overlay = OverlayScreen.CachetResultOverlay(result)
+                                qrPayload = ""
+                            }
                         }
                     }
                 },
                 onDecline = { overlay = null; qrPayload = "" },
                 onClose = { overlay = null; qrPayload = "" }
+            )
+            is OverlayScreen.LivenessCheck -> {
+                val packName = CachPackMapper.cachetDisplayName(screen.request.cachetType)
+                LivenessCheckScreen(
+                    packName = packName,
+                    onSimulatePass = {
+                        scope.launch {
+                            val result = viewModel.shareCredential(screen.request)
+                            overlay = OverlayScreen.CachetResultOverlay(result)
+                            qrPayload = ""
+                        }
+                    },
+                    onSimulateFail = {
+                        overlay = OverlayScreen.LivenessFailed(screen.request)
+                    },
+                    onCancel = {
+                        overlay = OverlayScreen.IncomingRequest(screen.request)
+                    }
+                )
+            }
+            is OverlayScreen.LivenessFailed -> LivenessFailedScreen(
+                onRetry = {
+                    overlay = OverlayScreen.LivenessCheck(screen.request)
+                },
+                onCancel = {
+                    overlay = null
+                    qrPayload = ""
+                }
             )
             is OverlayScreen.CachetResultOverlay -> CachetResultScreen(
                 result = screen.result,
@@ -271,9 +311,9 @@ fun WalletApp(demoMode: Boolean = false, demoEmpty: Boolean = false, demoScenari
                             }
                         }
                     } else {
-                        // Demo fallback
+                        // Demo fallback — use override pack if set, else first
                         overlay = OverlayScreen.IncomingRequest(
-                            CachPackMapper.toVerificationRequest(DemoFixtures.cachPacks.first())
+                            CachPackMapper.toVerificationRequest(DemoFixtures.effectiveScanPack)
                         )
                     }
                 },

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/WalletApp.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/WalletApp.kt
@@ -261,6 +261,7 @@ fun WalletApp(demoMode: Boolean = false, demoEmpty: Boolean = false, demoScenari
                 val packName = CachPackMapper.cachetDisplayName(screen.request.cachetType)
                 LivenessCheckScreen(
                     packName = packName,
+                    cachetType = screen.request.cachetType,
                     onSimulatePass = {
                         scope.launch {
                             val result = viewModel.shareCredential(screen.request)

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/mapper/CachPackMapper.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/mapper/CachPackMapper.kt
@@ -105,4 +105,12 @@ object CachPackMapper {
         CachetType.AGE -> "Age Verified"
         CachetType.IDENTITY -> "Identity Verified"
     }
+
+    /** User-facing pack name for the liveness explanation screen. */
+    fun cachetDisplayName(type: CachetType): String = when (type) {
+        CachetType.CHILDCARE -> "Childcare Readiness"
+        CachetType.SELLER -> "Safe Seller"
+        CachetType.AGE -> "Age Verification"
+        CachetType.IDENTITY -> "Identity Verification"
+    }
 }

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/onboarding/OnboardingScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/onboarding/OnboardingScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -213,7 +215,12 @@ fun OnboardingScreen(
             }
 
             // ── Pagination dots ──
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.semantics {
+                    contentDescription = "${currentPage + 1} of ${pages.size}"
+                }
+            ) {
                 repeat(pages.size) { index ->
                     Surface(
                         modifier = Modifier.size(8.dp),

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/IncomingRequestScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/IncomingRequestScreen.kt
@@ -30,7 +30,8 @@ fun IncomingRequestScreen(
     request: VerificationRequest,
     onShare: () -> Unit,
     onDecline: () -> Unit,
-    onClose: () -> Unit
+    onClose: () -> Unit,
+    requiresLiveness: Boolean = false
 ) {
     Surface(
         modifier = Modifier.fillMaxSize().testTag("incoming_request_screen"),
@@ -199,55 +200,70 @@ fun IncomingRequestScreen(
                 Spacer(modifier = Modifier.height(12.dp))
             }
 
-            // -- Consent metadata --
-            item {
-                Surface(
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(12.dp),
-                    color = SurfaceElevated
-                ) {
-                    Column(modifier = Modifier.padding(16.dp)) {
+            // -- Biometric notice (only when liveness required) --
+            if (requiresLiveness) {
+                item {
+                    Text(
+                        text = "Also required:",
+                        style = MaterialTheme.typography.bodySmall.copy(fontSize = 13.sp),
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Surface(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag("biometric_notice"),
+                        shape = RoundedCornerShape(12.dp),
+                        color = TrustPendingBg,
+                        border = androidx.compose.foundation.BorderStroke(1.dp, TrustPendingBorder)
+                    ) {
                         Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween
+                            modifier = Modifier.padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically
                         ) {
-                            Text(
-                                "Result kept by requester for",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = TextSecondary
-                            )
-                            Text(
-                                "${request.retentionDays} days",
-                                style = MaterialTheme.typography.bodySmall,
-                                fontWeight = FontWeight.SemiBold
-                            )
-                        }
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween
-                        ) {
-                            Text(
-                                "Logged in transparency log",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = TextSecondary
-                            )
-                            Text(
-                                if (request.loggedInTransparencyLog) "Yes" else "No",
-                                style = MaterialTheme.typography.bodySmall,
-                                fontWeight = FontWeight.SemiBold,
-                                color = if (request.loggedInTransparencyLog) BrandAccent else BrandWarm
-                            )
+                            // Face scan icon placeholder
+                            Surface(
+                                modifier = Modifier.size(32.dp),
+                                shape = CircleShape,
+                                color = Color.Transparent
+                            ) {
+                                Box(contentAlignment = Alignment.Center) {
+                                    Text("\uD83D\uDC64", fontSize = 20.sp)
+                                }
+                            }
+                            Spacer(modifier = Modifier.width(12.dp))
+                            Column {
+                                Text(
+                                    text = "A face scan to confirm you are the holder",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = TrustPendingText
+                                )
+                                Text(
+                                    text = "Processed by Veriff \u00B7 facial data is not stored after verification",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = TrustPendingText
+                                )
+                            }
                         }
                     }
+                    Spacer(modifier = Modifier.height(12.dp))
                 }
-                Spacer(modifier = Modifier.height(12.dp))
+            }
+
+            // -- Consent metadata (above CTA when no liveness, below CTA when liveness) --
+            if (!requiresLiveness) {
+                item {
+                    ConsentMetadata(request)
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
             }
 
             // -- Action buttons --
             item {
                 SealButton(
-                    text = "Verify & Share",
+                    text = if (requiresLiveness) "Verify with Face Scan" else "Verify & Share",
                     onClick = onShare
                 )
                 Spacer(modifier = Modifier.height(8.dp))
@@ -264,7 +280,79 @@ fun IncomingRequestScreen(
                         color = BrandWarm
                     )
                 }
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+
+            // -- Transparency log (compact, below CTA when liveness required) --
+            if (requiresLiveness) {
+                item {
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(10.dp),
+                        color = SurfaceElevated
+                    ) {
+                        Text(
+                            text = buildAnnotatedString {
+                                withStyle(SpanStyle(color = BrandAccent)) { append("\u2713 ") }
+                                append("Transparency log: results kept for ")
+                                withStyle(SpanStyle(fontWeight = FontWeight.SemiBold, color = TextPrimary)) {
+                                    append("${request.retentionDays} days")
+                                }
+                            },
+                            style = MaterialTheme.typography.labelSmall,
+                            color = TextSecondary,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 12.dp)
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConsentMetadata(request: VerificationRequest) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        color = SurfaceElevated
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    "Result kept by requester for",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = TextSecondary
+                )
+                Text(
+                    "${request.retentionDays} days",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    "Logged in transparency log",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = TextSecondary
+                )
+                Text(
+                    if (request.loggedInTransparencyLog) "Yes" else "No",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = if (request.loggedInTransparencyLog) BrandAccent else BrandWarm
+                )
             }
         }
     }

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/IncomingRequestScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/IncomingRequestScreen.kt
@@ -1,8 +1,9 @@
 package id.cachet.wallet.android.ui.verification
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -37,278 +38,259 @@ fun IncomingRequestScreen(
         modifier = Modifier.fillMaxSize().testTag("incoming_request_screen"),
         color = SurfaceBackground
     ) {
-        LazyColumn(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
+                .verticalScroll(rememberScrollState())
                 .padding(horizontal = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             // -- Close button --
-            item {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 8.dp)
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp)
+            ) {
+                IconButton(
+                    onClick = onClose,
+                    modifier = Modifier.align(Alignment.CenterEnd)
                 ) {
-                    IconButton(
-                        onClick = onClose,
-                        modifier = Modifier.align(Alignment.CenterEnd)
-                    ) {
-                        Icon(Icons.Default.Close, contentDescription = "Close", tint = TextTertiary)
-                    }
+                    Icon(Icons.Default.Close, contentDescription = "Close", tint = TextTertiary)
                 }
             }
 
             // -- Cachet shield with "?" badge --
-            item {
-                Spacer(modifier = Modifier.height(4.dp))
-                Box(contentAlignment = Alignment.BottomEnd) {
-                    CachetMark(type = request.cachetType, size = 72.dp)
-                    Surface(
-                        modifier = Modifier
-                            .size(28.dp)
-                            .offset(x = 4.dp, y = 4.dp),
-                        shape = CircleShape,
-                        color = Color.White,
-                        shadowElevation = 2.dp
-                    ) {
-                        Box(contentAlignment = Alignment.Center) {
-                            Text(
-                                text = "?",
-                                fontSize = 16.sp,
-                                fontWeight = FontWeight.Bold,
-                                color = BrandPrimary
+            Spacer(modifier = Modifier.height(4.dp))
+            Box(contentAlignment = Alignment.BottomEnd) {
+                CachetMark(type = request.cachetType, size = 72.dp)
+                Surface(
+                    modifier = Modifier
+                        .size(28.dp)
+                        .offset(x = 4.dp, y = 4.dp),
+                    shape = CircleShape,
+                    color = Color.White,
+                    shadowElevation = 2.dp
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Text(
+                            text = "?",
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = BrandPrimary
+                        )
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            if (!request.isVerifierVerified) {
+                Text(
+                    text = "Unverified requester",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = BrandWarm,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // -- Title + subtitle with verifier name in accent --
+            Text(
+                text = "Verification Request",
+                style = MaterialTheme.typography.headlineMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            val nameColor = if (request.isVerifierVerified) BrandAccent else TextPrimary
+            if (request.verifierName != null) {
+                Text(
+                    text = buildAnnotatedString {
+                        withStyle(SpanStyle(color = nameColor, fontWeight = FontWeight.SemiBold)) {
+                            append(request.verifierName)
+                        }
+                        append(" wants to know:")
+                    },
+                    style = MaterialTheme.typography.bodyLarge.copy(fontSize = 14.sp),
+                    color = TextSecondary,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            } else {
+                Text(
+                    text = "Someone wants to know:",
+                    style = MaterialTheme.typography.bodyLarge.copy(fontSize = 14.sp),
+                    color = TextSecondary,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // -- Question pill --
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                color = BrandPrimary
+            ) {
+                Text(
+                    text = request.question,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 12.dp),
+                    style = MaterialTheme.typography.titleLarge.copy(fontSize = 18.sp),
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color.White,
+                    textAlign = TextAlign.Center
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // -- "They will learn" header --
+            val rawCount = request.predicates.count {
+                it.disclosureType == id.cachet.wallet.android.ui.model.DisclosureType.RAW_VALUE
+            }
+            val predicateCount = request.predicates.size - rawCount
+            Text(
+                text = "They will learn:",
+                style = MaterialTheme.typography.bodySmall.copy(fontSize = 13.sp),
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.fillMaxWidth()
+            )
+            val subtitle = if (rawCount > 0) {
+                "$predicateCount derived facts, $rawCount shared as-is"
+            } else {
+                "Only these facts \u2014 nothing more"
+            }
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = if (rawCount > 0) BrandWarm else TextSecondary,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // -- Predicate list card --
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = SurfaceCard),
+                border = androidx.compose.foundation.BorderStroke(1.dp, SurfaceBorder)
+            ) {
+                Column(modifier = Modifier.padding(vertical = 8.dp)) {
+                    request.predicates.forEachIndexed { index, predicate ->
+                        PredicateRow(predicate)
+                        if (index < request.predicates.lastIndex) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(horizontal = 24.dp),
+                                color = SurfaceElevated
                             )
                         }
                     }
                 }
-                Spacer(modifier = Modifier.height(8.dp))
-                if (!request.isVerifierVerified) {
-                    Text(
-                        text = "Unverified requester",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = BrandWarm,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
-                Spacer(modifier = Modifier.height(8.dp))
             }
+            Spacer(modifier = Modifier.height(12.dp))
 
-            // -- Title + subtitle with verifier name in accent --
-            item {
+            // -- Biometric notice (only when liveness required) --
+            if (requiresLiveness) {
                 Text(
-                    text = "Verification Request",
-                    style = MaterialTheme.typography.headlineMedium,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth()
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                val nameColor = if (request.isVerifierVerified) BrandAccent else TextPrimary
-                if (request.verifierName != null) {
-                    Text(
-                        text = buildAnnotatedString {
-                            withStyle(SpanStyle(color = nameColor, fontWeight = FontWeight.SemiBold)) {
-                                append(request.verifierName)
-                            }
-                            append(" wants to know:")
-                        },
-                        style = MaterialTheme.typography.bodyLarge.copy(fontSize = 14.sp),
-                        color = TextSecondary,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                } else {
-                    Text(
-                        text = "Someone wants to know:",
-                        style = MaterialTheme.typography.bodyLarge.copy(fontSize = 14.sp),
-                        color = TextSecondary,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
-                Spacer(modifier = Modifier.height(12.dp))
-            }
-
-            // -- Question pill --
-            item {
-                Surface(
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(16.dp),
-                    color = BrandPrimary
-                ) {
-                    Text(
-                        text = request.question,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 24.dp, vertical = 12.dp),
-                        style = MaterialTheme.typography.titleLarge.copy(fontSize = 18.sp),
-                        fontWeight = FontWeight.SemiBold,
-                        color = Color.White,
-                        textAlign = TextAlign.Center
-                    )
-                }
-                Spacer(modifier = Modifier.height(12.dp))
-            }
-
-            // -- "They will learn" header --
-            item {
-                val rawCount = request.predicates.count {
-                    it.disclosureType == id.cachet.wallet.android.ui.model.DisclosureType.RAW_VALUE
-                }
-                val predicateCount = request.predicates.size - rawCount
-                Text(
-                    text = "They will learn:",
+                    text = "Also required:",
                     style = MaterialTheme.typography.bodySmall.copy(fontSize = 13.sp),
                     fontWeight = FontWeight.SemiBold,
                     modifier = Modifier.fillMaxWidth()
                 )
-                val subtitle = if (rawCount > 0) {
-                    "$predicateCount derived facts, $rawCount shared as-is"
-                } else {
-                    "Only these facts \u2014 nothing more"
-                }
-                Text(
-                    text = subtitle,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = if (rawCount > 0) BrandWarm else TextSecondary,
-                    modifier = Modifier.fillMaxWidth()
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-            }
-
-            // -- Predicate list card --
-            item {
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(16.dp),
-                    colors = CardDefaults.cardColors(containerColor = SurfaceCard),
-                    border = androidx.compose.foundation.BorderStroke(1.dp, SurfaceBorder)
+                Spacer(modifier = Modifier.height(4.dp))
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("biometric_notice"),
+                    shape = RoundedCornerShape(12.dp),
+                    color = TrustPendingBg,
+                    border = androidx.compose.foundation.BorderStroke(1.dp, TrustPendingBorder)
                 ) {
-                    Column(modifier = Modifier.padding(vertical = 8.dp)) {
-                        request.predicates.forEachIndexed { index, predicate ->
-                            PredicateRow(predicate)
-                            if (index < request.predicates.lastIndex) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(horizontal = 24.dp),
-                                    color = SurfaceElevated
-                                )
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        // Face scan icon placeholder
+                        Surface(
+                            modifier = Modifier.size(32.dp),
+                            shape = CircleShape,
+                            color = Color.Transparent
+                        ) {
+                            Box(contentAlignment = Alignment.Center) {
+                                Text("\uD83D\uDC64", fontSize = 20.sp)
                             }
+                        }
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column {
+                            Text(
+                                text = "A face scan to confirm you are the holder",
+                                style = MaterialTheme.typography.bodySmall,
+                                fontWeight = FontWeight.SemiBold,
+                                color = TrustPendingText
+                            )
+                            Text(
+                                text = "Processed by Veriff \u00B7 facial data is not stored after verification",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = TrustPendingText
+                            )
                         }
                     }
                 }
                 Spacer(modifier = Modifier.height(12.dp))
             }
 
-            // -- Biometric notice (only when liveness required) --
-            if (requiresLiveness) {
-                item {
-                    Text(
-                        text = "Also required:",
-                        style = MaterialTheme.typography.bodySmall.copy(fontSize = 13.sp),
-                        fontWeight = FontWeight.SemiBold,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Surface(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .testTag("biometric_notice"),
-                        shape = RoundedCornerShape(12.dp),
-                        color = TrustPendingBg,
-                        border = androidx.compose.foundation.BorderStroke(1.dp, TrustPendingBorder)
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(16.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            // Face scan icon placeholder
-                            Surface(
-                                modifier = Modifier.size(32.dp),
-                                shape = CircleShape,
-                                color = Color.Transparent
-                            ) {
-                                Box(contentAlignment = Alignment.Center) {
-                                    Text("\uD83D\uDC64", fontSize = 20.sp)
-                                }
-                            }
-                            Spacer(modifier = Modifier.width(12.dp))
-                            Column {
-                                Text(
-                                    text = "A face scan to confirm you are the holder",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    fontWeight = FontWeight.SemiBold,
-                                    color = TrustPendingText
-                                )
-                                Text(
-                                    text = "Processed by Veriff \u00B7 facial data is not stored after verification",
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = TrustPendingText
-                                )
-                            }
-                        }
-                    }
-                    Spacer(modifier = Modifier.height(12.dp))
-                }
-            }
-
             // -- Consent metadata (above CTA when no liveness, below CTA when liveness) --
             if (!requiresLiveness) {
-                item {
-                    ConsentMetadata(request)
-                    Spacer(modifier = Modifier.height(12.dp))
-                }
+                ConsentMetadata(request)
+                Spacer(modifier = Modifier.height(12.dp))
             }
 
             // -- Action buttons --
-            item {
-                SealButton(
-                    text = if (requiresLiveness) "Verify with Face Scan" else "Verify & Share",
-                    onClick = onShare
+            SealButton(
+                text = if (requiresLiveness) "Verify with Face Scan" else "Verify & Share",
+                onClick = onShare
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            TextButton(
+                onClick = onDecline,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(44.dp)
+            ) {
+                Text(
+                    "Decline",
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Medium,
+                    color = BrandWarm
                 )
-                Spacer(modifier = Modifier.height(8.dp))
-                TextButton(
-                    onClick = onDecline,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(44.dp)
-                ) {
-                    Text(
-                        "Decline",
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.Medium,
-                        color = BrandWarm
-                    )
-                }
-                Spacer(modifier = Modifier.height(4.dp))
             }
+            Spacer(modifier = Modifier.height(4.dp))
 
             // -- Transparency log (compact, below CTA when liveness required) --
             if (requiresLiveness) {
-                item {
-                    Surface(
-                        modifier = Modifier.fillMaxWidth(),
-                        shape = RoundedCornerShape(10.dp),
-                        color = SurfaceElevated
-                    ) {
-                        Text(
-                            text = buildAnnotatedString {
-                                withStyle(SpanStyle(color = BrandAccent)) { append("\u2713 ") }
-                                append("Transparency log: results kept for ")
-                                withStyle(SpanStyle(fontWeight = FontWeight.SemiBold, color = TextPrimary)) {
-                                    append("${request.retentionDays} days")
-                                }
-                            },
-                            style = MaterialTheme.typography.labelSmall,
-                            color = TextSecondary,
-                            textAlign = TextAlign.Center,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 12.dp)
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(16.dp))
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(10.dp),
+                    color = SurfaceElevated
+                ) {
+                    Text(
+                        text = buildAnnotatedString {
+                            withStyle(SpanStyle(color = BrandAccent)) { append("\u2713 ") }
+                            append("Transparency log: results kept for ")
+                            withStyle(SpanStyle(fontWeight = FontWeight.SemiBold, color = TextPrimary)) {
+                                append("${request.retentionDays} days")
+                            }
+                        },
+                        style = MaterialTheme.typography.labelSmall,
+                        color = TextSecondary,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 12.dp)
+                    )
                 }
+                Spacer(modifier = Modifier.height(16.dp))
             }
         }
     }

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/LivenessCheckScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/LivenessCheckScreen.kt
@@ -3,7 +3,9 @@ package id.cachet.wallet.android.ui.verification
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -229,6 +231,7 @@ fun LivenessFailedScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .verticalScroll(rememberScrollState())
                 .padding(horizontal = 24.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -339,7 +342,7 @@ fun LivenessFailedScreen(
                 }
             }
 
-            Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.height(32.dp))
 
             // Retry button
             Button(

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/LivenessCheckScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/LivenessCheckScreen.kt
@@ -5,8 +5,12 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.PriorityHigh
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -18,7 +22,94 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import id.cachet.wallet.android.ui.components.CachetType
+import id.cachet.wallet.android.ui.components.SealButton
 import id.cachet.wallet.android.ui.theme.*
+
+// ── Per-type accent color for pack name on liveness screen ──
+
+fun lisereForType(type: CachetType): Color = when (type) {
+    CachetType.CHILDCARE -> ShieldChildcareLisere
+    CachetType.SELLER -> ShieldSellerLisere
+    CachetType.AGE -> ShieldAgeLisere
+    CachetType.IDENTITY -> ShieldIdentityLisere
+}
+
+// ── Step indicator (shared by both screens) ──
+
+enum class StepState { DONE, ACTIVE, FAILED, PENDING }
+
+@Composable
+fun StepIndicator(steps: List<StepState>) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        steps.forEachIndexed { index, state ->
+            if (index > 0) {
+                Box(
+                    modifier = Modifier
+                        .width(24.dp)
+                        .height(2.dp)
+                        .background(SurfaceBorderDark)
+                )
+            }
+            when (state) {
+                StepState.DONE -> Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .clip(CircleShape)
+                        .background(BrandAccent),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        Icons.Default.Check,
+                        contentDescription = null,
+                        modifier = Modifier.size(10.dp),
+                        tint = TextOnBrand
+                    )
+                }
+                StepState.ACTIVE -> Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .clip(CircleShape)
+                        .background(BrandAccent)
+                        .border(2.dp, BrandAccentLight, CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(6.dp)
+                            .clip(CircleShape)
+                            .background(TextOnBrand)
+                    )
+                }
+                StepState.FAILED -> Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .clip(CircleShape)
+                        .background(BrandWarm)
+                        .border(2.dp, TrustRevokedBorder, CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        Icons.Default.PriorityHigh,
+                        contentDescription = null,
+                        modifier = Modifier.size(10.dp),
+                        tint = TextOnBrand
+                    )
+                }
+                StepState.PENDING -> Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .clip(CircleShape)
+                        .background(SurfaceBorderDark)
+                )
+            }
+        }
+    }
+}
 
 /**
  * Liveness check screen — shown between consent and signing for high-value packs.
@@ -29,6 +120,7 @@ import id.cachet.wallet.android.ui.theme.*
 @Composable
 fun LivenessCheckScreen(
     packName: String,
+    cachetType: CachetType = CachetType.CHILDCARE,
     onSimulatePass: () -> Unit,
     onSimulateFail: () -> Unit,
     onCancel: () -> Unit
@@ -37,76 +129,39 @@ fun LivenessCheckScreen(
         modifier = Modifier
             .fillMaxSize()
             .testTag("liveness_check_screen"),
-        color = Color(0xFF0F172A)
+        color = BrandPrimaryDark
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .statusBarsPadding()
                 .padding(horizontal = 24.dp)
         ) {
-            Spacer(modifier = Modifier.height(48.dp))
-
-            // Step indicator: Consent [done] > Liveness [active] > Result [pending]
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically
+            // ── Top bar: close X (right-aligned) ──
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp)
             ) {
-                // Step 1: Consent (done)
-                Box(
-                    modifier = Modifier
-                        .size(16.dp)
-                        .clip(CircleShape)
-                        .background(BrandAccent),
-                    contentAlignment = Alignment.Center
+                IconButton(
+                    onClick = onCancel,
+                    modifier = Modifier.align(Alignment.CenterEnd)
                 ) {
-                    Text("\u2713", fontSize = 10.sp, color = Color.White, fontWeight = FontWeight.Bold)
+                    Icon(Icons.Default.Close, contentDescription = "Close", tint = TextSecondaryDark)
                 }
-                Box(
-                    modifier = Modifier
-                        .width(24.dp)
-                        .height(2.dp)
-                        .background(Color(0xFF334155))
-                )
-                // Step 2: Liveness (active)
-                Box(
-                    modifier = Modifier
-                        .size(16.dp)
-                        .clip(CircleShape)
-                        .background(BrandAccent)
-                        .border(2.dp, Color(0xFF34D399), CircleShape),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .size(6.dp)
-                            .clip(CircleShape)
-                            .background(Color.White)
-                    )
-                }
-                Box(
-                    modifier = Modifier
-                        .width(24.dp)
-                        .height(2.dp)
-                        .background(Color(0xFF334155))
-                )
-                // Step 3: Result (pending)
-                Box(
-                    modifier = Modifier
-                        .size(16.dp)
-                        .clip(CircleShape)
-                        .background(Color(0xFF334155))
-                )
             }
+
+            // ── Step indicator ──
+            StepIndicator(listOf(StepState.DONE, StepState.ACTIVE, StepState.PENDING))
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            // Header
+            // ── Header ──
             Text(
                 text = "Prove it\u2019s you",
-                style = MaterialTheme.typography.headlineSmall,
+                style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Bold,
-                color = Color.White,
+                color = TextOnBrand,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.fillMaxWidth()
             )
@@ -114,7 +169,7 @@ fun LivenessCheckScreen(
             Text(
                 text = "A quick identity check is required for",
                 style = MaterialTheme.typography.bodyMedium,
-                color = Color(0xFF94A3B8),
+                color = TextSecondaryDark,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.fillMaxWidth()
             )
@@ -122,21 +177,21 @@ fun LivenessCheckScreen(
                 text = packName,
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.SemiBold,
-                color = Color(0xFFD88AA0),
+                color = lisereForType(cachetType),
                 textAlign = TextAlign.Center,
                 modifier = Modifier.fillMaxWidth()
             )
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            // Camera area (demo placeholder)
+            // ── Camera area (demo placeholder) ──
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .aspectRatio(1f)
                     .clip(CircleShape)
-                    .background(Color(0xFF1E293B))
-                    .border(2.dp, Color(0xFF334155), CircleShape)
+                    .background(BrandPrimary)
+                    .border(2.dp, SurfaceBorderDark, CircleShape)
                     .testTag("liveness_camera_area"),
                 contentAlignment = Alignment.Center
             ) {
@@ -144,24 +199,24 @@ fun LivenessCheckScreen(
                     Text(
                         text = "Camera preview",
                         style = MaterialTheme.typography.bodySmall,
-                        color = Color(0xFF64748B)
+                        color = TrustNeutral
                     )
                     Text(
                         text = "(Veriff SDK in production)",
                         style = MaterialTheme.typography.labelSmall,
-                        color = Color(0xFF475569)
+                        color = TextTertiaryDark
                     )
                 }
             }
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            // Trust explanation
+            // ── Trust explanation card ──
             Surface(
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(12.dp),
-                color = Color(0xFF1E293B),
-                border = androidx.compose.foundation.BorderStroke(1.dp, Color(0xFF334155))
+                color = BrandPrimary,
+                border = androidx.compose.foundation.BorderStroke(1.dp, SurfaceBorderDark)
             ) {
                 Row(modifier = Modifier.padding(16.dp)) {
                     Text("\uD83D\uDEE1\uFE0F", fontSize = 16.sp)
@@ -169,46 +224,59 @@ fun LivenessCheckScreen(
                     Text(
                         text = "This check ensures only you can sign this high-value verification response.",
                         style = MaterialTheme.typography.bodySmall,
-                        color = Color(0xFF94A3B8)
+                        color = TextSecondaryDark
                     )
                 }
             }
 
             Spacer(modifier = Modifier.weight(1f))
 
-            // Demo controls: Simulate Pass / Simulate Fail
+            // ── Demo controls: Simulate Pass / Simulate Fail ──
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                Button(
-                    onClick = onSimulatePass,
-                    modifier = Modifier.weight(1f),
-                    colors = ButtonDefaults.buttonColors(containerColor = BrandAccent),
-                    shape = RoundedCornerShape(28.dp)
-                ) {
-                    Text("Simulate Pass", fontWeight = FontWeight.SemiBold)
+                Box(modifier = Modifier.weight(1f)) {
+                    SealButton(
+                        text = "Simulate Pass",
+                        onClick = onSimulatePass
+                    )
                 }
                 OutlinedButton(
                     onClick = onSimulateFail,
-                    modifier = Modifier.weight(1f),
-                    shape = RoundedCornerShape(28.dp)
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(56.dp),
+                    shape = RoundedCornerShape(28.dp),
+                    border = androidx.compose.foundation.BorderStroke(1.5.dp, SurfaceBorderDark)
                 ) {
-                    Text("Simulate Fail", color = Color(0xFFF97068))
+                    Text(
+                        "Simulate Fail",
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Medium,
+                        color = BrandWarm
+                    )
                 }
             }
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            // Cancel
+            // ── Cancel ──
             TextButton(
                 onClick = onCancel,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text("Cancel", color = Color(0xFF94A3B8))
+                Text(
+                    "Cancel",
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Medium,
+                    color = TextSecondaryDark
+                )
             }
 
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier
+                .navigationBarsPadding()
+                .height(8.dp))
         }
     }
 }
@@ -226,104 +294,90 @@ fun LivenessFailedScreen(
         modifier = Modifier
             .fillMaxSize()
             .testTag("liveness_failed_screen"),
-        color = Color(0xFF0F172A)
+        color = BrandPrimaryDark
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
+                .statusBarsPadding()
                 .padding(horizontal = 24.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Spacer(modifier = Modifier.height(48.dp))
-
-            // Step indicator: Consent [done] > Liveness [failed] > Result [pending]
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically
+            // ── Top bar: close X (right-aligned) ──
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp)
             ) {
-                Box(
-                    modifier = Modifier
-                        .size(16.dp)
-                        .clip(CircleShape)
-                        .background(BrandAccent),
-                    contentAlignment = Alignment.Center
+                IconButton(
+                    onClick = onCancel,
+                    modifier = Modifier.align(Alignment.CenterEnd)
                 ) {
-                    Text("\u2713", fontSize = 10.sp, color = Color.White, fontWeight = FontWeight.Bold)
+                    Icon(Icons.Default.Close, contentDescription = "Close", tint = TextSecondaryDark)
                 }
-                Box(modifier = Modifier.width(24.dp).height(2.dp).background(Color(0xFF334155)))
-                Box(
-                    modifier = Modifier
-                        .size(16.dp)
-                        .clip(CircleShape)
-                        .background(Color(0xFFEF4444))
-                        .border(2.dp, Color(0xFFF87171), CircleShape),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text("!", fontSize = 10.sp, color = Color.White, fontWeight = FontWeight.Bold)
-                }
-                Box(modifier = Modifier.width(24.dp).height(2.dp).background(Color(0xFF334155)))
-                Box(
-                    modifier = Modifier
-                        .size(16.dp)
-                        .clip(CircleShape)
-                        .background(Color(0xFF334155))
-                )
             }
+
+            // ── Step indicator ──
+            StepIndicator(listOf(StepState.DONE, StepState.FAILED, StepState.PENDING))
 
             Spacer(modifier = Modifier.height(64.dp))
 
-            // Failure icon
+            // ── Failure icon — Material Close icon, properly centered ──
             Box(
                 modifier = Modifier
                     .size(160.dp)
                     .clip(CircleShape)
-                    .background(Color(0xFF1E293B))
-                    .border(2.dp, Color(0xFF7F1D1D), CircleShape),
+                    .background(BrandPrimary)
+                    .border(2.dp, TrustRevokedText, CircleShape),
                 contentAlignment = Alignment.Center
             ) {
-                Text("\u2717", fontSize = 48.sp, color = Color(0xFFEF4444))
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = "Failed",
+                    modifier = Modifier.size(64.dp),
+                    tint = BrandWarm
+                )
             }
 
             Spacer(modifier = Modifier.height(32.dp))
 
             Text(
                 text = "We couldn\u2019t confirm it\u2019s you",
-                style = MaterialTheme.typography.headlineSmall,
+                style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Bold,
-                color = Color.White,
+                color = TextOnBrand,
                 textAlign = TextAlign.Center
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = "The identity check didn\u2019t pass.",
                 style = MaterialTheme.typography.bodyMedium,
-                color = Color(0xFF94A3B8),
+                color = TextSecondaryDark,
                 textAlign = TextAlign.Center
             )
             Text(
                 text = "No credentials were shared.",
                 style = MaterialTheme.typography.bodyMedium,
-                color = Color(0xFF94A3B8),
+                color = TextSecondaryDark,
                 textAlign = TextAlign.Center
             )
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            // Tips
+            // ── Tips card ──
             Surface(
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(16.dp),
-                color = Color(0xFF1E293B),
-                border = androidx.compose.foundation.BorderStroke(1.dp, Color(0xFF334155))
+                color = BrandPrimary,
+                border = androidx.compose.foundation.BorderStroke(1.dp, SurfaceBorderDark)
             ) {
                 Column(modifier = Modifier.padding(16.dp)) {
                     Text(
                         text = "Tips for next time",
                         style = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.SemiBold,
-                        color = Color.White
+                        color = TextOnBrand
                     )
                     Spacer(modifier = Modifier.height(12.dp))
                     for (tip in listOf(
@@ -335,7 +389,7 @@ fun LivenessFailedScreen(
                         Text(
                             text = "\u2022  $tip",
                             style = MaterialTheme.typography.bodySmall,
-                            color = Color(0xFF94A3B8),
+                            color = TextSecondaryDark,
                             modifier = Modifier.padding(vertical = 2.dp)
                         )
                     }
@@ -344,29 +398,30 @@ fun LivenessFailedScreen(
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            // Retry button
-            Button(
-                onClick = onRetry,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(56.dp),
-                colors = ButtonDefaults.buttonColors(containerColor = BrandAccent),
-                shape = RoundedCornerShape(28.dp)
-            ) {
-                Text("Try Again", fontWeight = FontWeight.SemiBold, fontSize = 16.sp)
-            }
+            // ── Retry button (SealButton) ──
+            SealButton(
+                text = "Try Again",
+                onClick = onRetry
+            )
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            // Cancel
+            // ── Cancel ──
             TextButton(
                 onClick = onCancel,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text("Cancel verification", color = Color(0xFFF97068))
+                Text(
+                    "Cancel verification",
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Medium,
+                    color = BrandWarm
+                )
             }
 
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier
+                .navigationBarsPadding()
+                .height(8.dp))
         }
     }
 }

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/LivenessCheckScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/LivenessCheckScreen.kt
@@ -134,6 +134,7 @@ fun LivenessCheckScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .verticalScroll(rememberScrollState())
                 .statusBarsPadding()
                 .padding(horizontal = 24.dp)
         ) {
@@ -229,7 +230,7 @@ fun LivenessCheckScreen(
                 }
             }
 
-            Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.height(24.dp))
 
             // ── Demo controls: Simulate Pass / Simulate Fail ──
             Row(

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/LivenessCheckScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/LivenessCheckScreen.kt
@@ -1,0 +1,369 @@
+package id.cachet.wallet.android.ui.verification
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import id.cachet.wallet.android.ui.theme.*
+
+/**
+ * Liveness check screen — shown between consent and signing for high-value packs.
+ *
+ * In demo mode, shows a simulated camera area with pass/fail buttons.
+ * In production, this will launch the Veriff SDK.
+ */
+@Composable
+fun LivenessCheckScreen(
+    packName: String,
+    onSimulatePass: () -> Unit,
+    onSimulateFail: () -> Unit,
+    onCancel: () -> Unit
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("liveness_check_screen"),
+        color = Color(0xFF0F172A)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp)
+        ) {
+            Spacer(modifier = Modifier.height(48.dp))
+
+            // Step indicator: Consent [done] > Liveness [active] > Result [pending]
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Step 1: Consent (done)
+                Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .clip(CircleShape)
+                        .background(BrandAccent),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text("\u2713", fontSize = 10.sp, color = Color.White, fontWeight = FontWeight.Bold)
+                }
+                Box(
+                    modifier = Modifier
+                        .width(24.dp)
+                        .height(2.dp)
+                        .background(Color(0xFF334155))
+                )
+                // Step 2: Liveness (active)
+                Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .clip(CircleShape)
+                        .background(BrandAccent)
+                        .border(2.dp, Color(0xFF34D399), CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(6.dp)
+                            .clip(CircleShape)
+                            .background(Color.White)
+                    )
+                }
+                Box(
+                    modifier = Modifier
+                        .width(24.dp)
+                        .height(2.dp)
+                        .background(Color(0xFF334155))
+                )
+                // Step 3: Result (pending)
+                Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFF334155))
+                )
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // Header
+            Text(
+                text = "Prove it\u2019s you",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = Color.White,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "A quick identity check is required for",
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color(0xFF94A3B8),
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Text(
+                text = packName,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = Color(0xFFD88AA0),
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // Camera area (demo placeholder)
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1f)
+                    .clip(CircleShape)
+                    .background(Color(0xFF1E293B))
+                    .border(2.dp, Color(0xFF334155), CircleShape)
+                    .testTag("liveness_camera_area"),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = "Camera preview",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color(0xFF64748B)
+                    )
+                    Text(
+                        text = "(Veriff SDK in production)",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = Color(0xFF475569)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Trust explanation
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                color = Color(0xFF1E293B),
+                border = androidx.compose.foundation.BorderStroke(1.dp, Color(0xFF334155))
+            ) {
+                Row(modifier = Modifier.padding(16.dp)) {
+                    Text("\uD83D\uDEE1\uFE0F", fontSize = 16.sp)
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = "This check ensures only you can sign this high-value verification response.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color(0xFF94A3B8)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // Demo controls: Simulate Pass / Simulate Fail
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Button(
+                    onClick = onSimulatePass,
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.buttonColors(containerColor = BrandAccent),
+                    shape = RoundedCornerShape(28.dp)
+                ) {
+                    Text("Simulate Pass", fontWeight = FontWeight.SemiBold)
+                }
+                OutlinedButton(
+                    onClick = onSimulateFail,
+                    modifier = Modifier.weight(1f),
+                    shape = RoundedCornerShape(28.dp)
+                ) {
+                    Text("Simulate Fail", color = Color(0xFFF97068))
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Cancel
+            TextButton(
+                onClick = onCancel,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Cancel", color = Color(0xFF94A3B8))
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}
+
+/**
+ * Liveness failure screen — shown when the Veriff identity check fails.
+ * Deliberately vague about failure reason (security).
+ */
+@Composable
+fun LivenessFailedScreen(
+    onRetry: () -> Unit,
+    onCancel: () -> Unit
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("liveness_failed_screen"),
+        color = Color(0xFF0F172A)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.height(48.dp))
+
+            // Step indicator: Consent [done] > Liveness [failed] > Result [pending]
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .clip(CircleShape)
+                        .background(BrandAccent),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text("\u2713", fontSize = 10.sp, color = Color.White, fontWeight = FontWeight.Bold)
+                }
+                Box(modifier = Modifier.width(24.dp).height(2.dp).background(Color(0xFF334155)))
+                Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFFEF4444))
+                        .border(2.dp, Color(0xFFF87171), CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text("!", fontSize = 10.sp, color = Color.White, fontWeight = FontWeight.Bold)
+                }
+                Box(modifier = Modifier.width(24.dp).height(2.dp).background(Color(0xFF334155)))
+                Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFF334155))
+                )
+            }
+
+            Spacer(modifier = Modifier.height(64.dp))
+
+            // Failure icon
+            Box(
+                modifier = Modifier
+                    .size(160.dp)
+                    .clip(CircleShape)
+                    .background(Color(0xFF1E293B))
+                    .border(2.dp, Color(0xFF7F1D1D), CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                Text("\u2717", fontSize = 48.sp, color = Color(0xFFEF4444))
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Text(
+                text = "We couldn\u2019t confirm it\u2019s you",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = Color.White,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "The identity check didn\u2019t pass.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color(0xFF94A3B8),
+                textAlign = TextAlign.Center
+            )
+            Text(
+                text = "No credentials were shared.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color(0xFF94A3B8),
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // Tips
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                color = Color(0xFF1E293B),
+                border = androidx.compose.foundation.BorderStroke(1.dp, Color(0xFF334155))
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text(
+                        text = "Tips for next time",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = Color.White
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    for (tip in listOf(
+                        "Make sure your face is well-lit",
+                        "Remove sunglasses or face coverings",
+                        "Look straight at the camera, at eye level",
+                        "Look as you did when you set up your ID"
+                    )) {
+                        Text(
+                            text = "\u2022  $tip",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color(0xFF94A3B8),
+                            modifier = Modifier.padding(vertical = 2.dp)
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // Retry button
+            Button(
+                onClick = onRetry,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = BrandAccent),
+                shape = RoundedCornerShape(28.dp)
+            ) {
+                Text("Try Again", fontWeight = FontWeight.SemiBold, fontSize = 16.sp)
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Cancel
+            TextButton(
+                onClick = onCancel,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Cancel verification", color = Color(0xFFF97068))
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}

--- a/mobile/androidApp/src/prod/kotlin/id/cachet/wallet/android/ui/fixtures/DemoFixtures.kt
+++ b/mobile/androidApp/src/prod/kotlin/id/cachet/wallet/android/ui/fixtures/DemoFixtures.kt
@@ -10,7 +10,6 @@ import id.cachet.wallet.domain.model.VerifiableCredential
  * it means demo code leaked into a non-demo code path.
  */
 object DemoFixtures {
-    @Volatile
     var isDemoActive: Boolean
         get() = false
         set(_) = error("Demo not available in production")
@@ -31,7 +30,19 @@ object DemoFixtures {
     val ageRequest: VerificationRequest get() = error("Demo not available in production")
     val qrShareState: QrShareState get() = error("Demo not available in production")
 
+    var overrideScanPack: CachPackUi?
+        get() = null
+        set(_) = error("Demo not available in production")
+
+    enum class LivenessResult { PASS, FAIL, NONE }
+    var livenessResult: LivenessResult
+        get() = LivenessResult.NONE
+        set(_) = error("Demo not available in production")
+
+    val effectiveScanPack: CachPackUi get() = error("Demo not available in production")
+
     fun detailFor(localId: String): CachetDetailUi? = error("Demo not available in production")
     fun packForType(type: CachetType): CachPackUi = error("Demo not available in production")
     fun shouldPass(request: VerificationRequest): Boolean = error("Demo not available in production")
+    fun requiresLiveness(type: CachetType): Boolean = false
 }

--- a/mobile/gradle/libs.versions.toml
+++ b/mobile/gradle/libs.versions.toml
@@ -46,7 +46,7 @@ zxing = "3.5.4"
 junit = "4.13.2"
 test-ext-junit = "1.3.0"
 espresso = "3.7.0"
-cucumber = "7.34.3"
+cucumber = "7.18.1"
 cucumber-android = "7.18.1"
 
 [libraries]

--- a/spec/wallet/verification-flow/stories/liveness-before-signing/scenarios.feature
+++ b/spec/wallet/verification-flow/stories/liveness-before-signing/scenarios.feature
@@ -30,11 +30,18 @@ Feature: Holder identity confirmation before signing high-value verifications
     Given the app is launched in demo mode
     And I hold a valid credential
 
-  # AC-1: Liveness required for high-value cachets
+  # AC-1: Biometric consent shown on consent screen for high-value cachets
+  @wireframe:cachet-03-incoming-request-biometric.svg
+  Scenario: Consent screen shows biometric notice for high-value cachet
+    Given I am on the Incoming Request screen for a "Childcare Readiness" pack
+    Then I see a face scan notice
+    And the action button reads "Verify with Face Scan"
+
+  # AC-1b: Tapping the biometric CTA triggers liveness check
   @wireframe:cachet-03b-liveness-check.svg
   Scenario: High-value cachet triggers liveness check after consent
     Given I am on the Incoming Request screen for a "Childcare Readiness" pack
-    When I tap "Verify & Share"
+    When I tap "Verify with Face Scan"
     Then I see the Liveness Check screen
     And the screen explains why liveness is needed
     And the front camera activates for the Veriff liveness session
@@ -43,6 +50,7 @@ Feature: Holder identity confirmation before signing high-value verifications
   @wireframe:cachet-03-incoming-request.svg @wireframe:cachet-04-result-pass.svg
   Scenario: Low-value cachet skips liveness check
     Given I am on the Incoming Request screen for an "Age Verification" pack
+    Then the action button reads "Verify & Share"
     When I tap "Verify & Share"
     Then the verification is performed without a liveness check
     And I see the Verification Result screen
@@ -76,12 +84,12 @@ Feature: Holder identity confirmation before signing high-value verifications
   # AC-6: Liveness requirement is per-CachPack
   Scenario Outline: Liveness requirement varies by CachPack — <pack>
     Given I am on the Incoming Request screen for a "<pack>" pack
-    When I tap "Verify & Share"
+    When I tap "<cta>"
     Then <outcome>
 
     Examples:
-      | pack                  | outcome                                  |
-      | Childcare Readiness   | I see the Liveness Check screen          |
-      | Safe Seller           | I see the Liveness Check screen          |
-      | Identity Verification | I see the Liveness Check screen          |
-      | Age Verification      | the verification completes without liveness |
+      | pack                  | cta                    | outcome                                    |
+      | Childcare Readiness   | Verify with Face Scan  | I see the Liveness Check screen             |
+      | Safe Seller           | Verify with Face Scan  | I see the Liveness Check screen             |
+      | Identity Verification | Verify with Face Scan  | I see the Liveness Check screen             |
+      | Age Verification      | Verify & Share         | the verification completes without liveness |

--- a/spec/wallet/verification-flow/stories/liveness-before-signing/scenarios.feature
+++ b/spec/wallet/verification-flow/stories/liveness-before-signing/scenarios.feature
@@ -1,0 +1,87 @@
+@story:liveness-before-signing @domain:wallet/verification-flow @priority:must @issue:58
+Feature: Holder identity confirmation before signing high-value verifications
+  As a returning-holder
+  I want to prove I am the credential holder before my wallet signs a high-value verification response
+  So that nobody else can use my phone to impersonate me for consequential checks
+
+  Context:
+    After the holder taps "Verify & Share" on the consent screen, the wallet
+    checks the CachPack policy. High-value packs (e.g. Childcare Readiness)
+    require a Veriff Biometric Authentication — a camera-based face match
+    against the enrollment from the original identity verification at issuance
+    — before the KB-JWT is signed and the presentation sent.
+    Low-value packs (e.g. Age) skip straight to signing.
+
+    This is NOT on-device biometrics (fingerprint/face unlock). Veriff
+    Biometric Authentication combines passive liveness detection (anti-spoofing)
+    with face matching against the holder's enrollment template, proving both
+    that the person is real AND that they are the credential holder.
+
+    The Veriff SDK owns the capture UX (selfie guidance, camera framing).
+    Our screens are the before/after wrapper: explanation → SDK → result.
+
+  Out of scope:
+    - Verifier-forced identity confirmation (future: verifier request can override pack policy)
+    - On-device biometrics (not needed — Veriff handles liveness + face match)
+    - Liveness during issuance (separate flow, already handled by Veriff KYC)
+    - Distinguishing failure reasons to the user (security: never reveal why match failed)
+
+  Background:
+    Given the app is launched in demo mode
+    And I hold a valid credential
+
+  # AC-1: Liveness required for high-value cachets
+  @wireframe:cachet-03b-liveness-check.svg
+  Scenario: High-value cachet triggers liveness check after consent
+    Given I am on the Incoming Request screen for a "Childcare Readiness" pack
+    When I tap "Verify & Share"
+    Then I see the Liveness Check screen
+    And the screen explains why liveness is needed
+    And the front camera activates for the Veriff liveness session
+
+  # AC-2: Liveness not required for low-value cachets
+  @wireframe:cachet-03-incoming-request.svg @wireframe:cachet-04-result-pass.svg
+  Scenario: Low-value cachet skips liveness check
+    Given I am on the Incoming Request screen for an "Age Verification" pack
+    When I tap "Verify & Share"
+    Then the verification is performed without a liveness check
+    And I see the Verification Result screen
+
+  # AC-3: Successful liveness leads to signing and result
+  @wireframe:cachet-03b-liveness-check.svg @wireframe:cachet-04-result-pass.svg
+  Scenario: Liveness passes and verification completes
+    Given I am on the Liveness Check screen
+    When the Veriff liveness check succeeds
+    Then the KB-JWT is signed and the presentation is sent
+    And I see the Verification Result screen
+
+  # AC-4: Failed liveness blocks signing
+  @wireframe:cachet-03b-liveness-failed.svg
+  Scenario: Liveness fails and signing is blocked
+    Given I am on the Liveness Check screen
+    When the Veriff liveness check fails
+    Then the KB-JWT is not signed
+    And I see a liveness failure message
+    And I can retry the liveness check or cancel
+
+  # AC-5: Holder cancels liveness
+  @wireframe:cachet-03b-liveness-check.svg
+  Scenario: Holder cancels liveness check
+    Given I am on the Liveness Check screen
+    When I tap "Cancel"
+    Then the KB-JWT is not signed
+    And I return to the Incoming Request screen
+    And no credentials are shared
+
+  # AC-6: Liveness requirement is per-CachPack
+  Scenario Outline: Liveness requirement varies by CachPack — <pack>
+    Given I am on the Incoming Request screen for a "<pack>" pack
+    When I tap "Verify & Share"
+    Then <outcome>
+
+    Examples:
+      | pack                  | outcome                                  |
+      | Childcare Readiness   | I see the Liveness Check screen          |
+      | Safe Seller           | I see the Liveness Check screen          |
+      | Identity Verification | I see the Liveness Check screen          |
+      | Age Verification      | the verification completes without liveness |


### PR DESCRIPTION
## Summary
- **Liveness gate (#58):** High-value CachPacks (Childcare, Seller, Identity) now require a Veriff Biometric Authentication step between consent and KB-JWT signing. Low-value packs (Age) skip straight to the result.
- **BIPA consent (#58):** Biometric consent disclosure with explicit opt-in before any liveness check, compliant with Illinois BIPA requirements.
- **Deep link holder flow (#60):** `cachet://verify` deep links resolve to the consent screen, with expired session handling and identity cachet guard.
- **BDD green:** All 80 Cucumber scenarios pass on Android emulator.

## Changes
- LivenessCheckScreen + LivenessFailedScreen composables (demo mode)
- BIPA-compliant biometric consent on IncomingRequestScreen
- Per-pack liveness policy via `DemoFixtures.requiresLiveness()`
- Liveness gate in WalletApp `onShare` callback
- Deep link activity, expired session screen, consent routing
- BDD step definitions for all acceptance criteria
- `passLivenessIfNeeded()` helper for BDD navigation through liveness gate
- Onboarding pagination dots now have accessibility semantics
- devenv: `gradle` → `./gradlew` in android:bdd and android:test-unit tasks
- Wireframes: cachet-03b-liveness-check.svg, cachet-03b-liveness-failed.svg, cachet-04-deep-link-expired.svg
- Veriff Biometric Authentication research doc

## Test plan
- [x] Visual verification on emulator: Simulate Pass → result screen, Simulate Fail → failure screen matches wireframe
- [x] 80/80 BDD Cucumber scenarios pass (`devenv shell -- android:bdd`)
- [x] Smoke test deep link flow: `adb shell am start -a android.intent.action.VIEW -d "cachet://verify?pack=childcare"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)