### PR TITLE
feat: GCP Cloud Monitoring dashboard + alert policies (#101)

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -175,9 +175,11 @@ in
     echo "  android:empty        Empty vault (IDV onboarding)"
     echo ""
     echo "GCP (requires gcloud CLI):"
-    echo "  gcp:setup           Setup GCP project"
-    echo "  gcp:deploy:verifier Deploy to Cloud Run"
-    echo "  gcp:status          Check deployment status"
+    echo "  gcp:setup              Setup GCP project"
+    echo "  gcp:deploy:verifier    Deploy to Cloud Run"
+    echo "  gcp:status             Check deployment status"
+    echo "  gcp:monitoring:setup   Create alerts + dashboard"
+    echo "  gcp:monitoring:status  Show monitoring resources"
   '';
   scripts."fmt:go".exec = "gofmt -s -w services";
   scripts."lint:go".exec = ''
@@ -683,6 +685,7 @@ in
       secretmanager.googleapis.com
       containerregistry.googleapis.com
       cloudresourcemanager.googleapis.com
+      monitoring.googleapis.com
     )
     
     for api in "''${APIS[@]}"; do
@@ -889,6 +892,76 @@ EOF
     echo "   • Production uses Secret Manager via Cloud Run"  
     echo "   • Same secret names and consistent access pattern"
     echo "   • Service deployed and functional"
+  '';
+
+  scripts."gcp:monitoring:setup".exec = ''
+    echo "📊 Setting up GCP Cloud Monitoring for Cachet..."
+    set -euo pipefail
+
+    PROJECT_ID=$(gcloud config get-value project)
+    if [ -z "$PROJECT_ID" ]; then
+      echo "❌ No GCP project set. Run 'gcp:setup' first."
+      exit 1
+    fi
+
+    echo "🔧 Enabling Monitoring API..."
+    gcloud services enable monitoring.googleapis.com --quiet || true
+
+    echo "📈 Creating operations dashboard..."
+    if gcloud monitoring dashboards list --format="value(name)" | grep -q "Cachet Operations"; then
+      echo "   Dashboard already exists, updating..."
+      DASH_NAME=$(gcloud monitoring dashboards list --format="value(name)" --filter="displayName='Cachet Operations'" | head -1)
+      gcloud monitoring dashboards update "$DASH_NAME" --config-from-file=infra/monitoring/dashboard.json
+    else
+      gcloud monitoring dashboards create --config-from-file=infra/monitoring/dashboard.json
+    fi
+    echo "   ✅ Dashboard created"
+
+    echo "🚨 Creating alert policies..."
+    ALERTS=$(cat infra/monitoring/alerts.json)
+    POLICY_COUNT=$(echo "$ALERTS" | jq '.policies | length')
+    for i in $(seq 0 $((POLICY_COUNT - 1))); do
+      POLICY_NAME=$(echo "$ALERTS" | jq -r ".policies[$i].displayName")
+      POLICY_JSON=$(echo "$ALERTS" | jq ".policies[$i]")
+
+      # Check if policy already exists
+      if gcloud alpha monitoring policies list --format="value(displayName)" 2>/dev/null | grep -qF "$POLICY_NAME"; then
+        echo "   ⏭️  $POLICY_NAME (already exists)"
+      else
+        echo "$POLICY_JSON" | gcloud alpha monitoring policies create --policy-from-file=- 2>/dev/null && \
+          echo "   ✅ $POLICY_NAME" || \
+          echo "   ⚠️  $POLICY_NAME (failed — may need notification channel first)"
+      fi
+    done
+
+    echo ""
+    echo "✅ Monitoring setup complete!"
+    echo "📝 Next steps:"
+    echo "   1. Create a notification channel: https://console.cloud.google.com/monitoring/alerting/notifications?project=$PROJECT_ID"
+    echo "   2. Link it to the alert policies above"
+    echo "   3. View dashboard: https://console.cloud.google.com/monitoring/dashboards?project=$PROJECT_ID"
+  '';
+
+  scripts."gcp:monitoring:status".exec = ''
+    echo "📊 Cachet Monitoring Status"
+    set -euo pipefail
+
+    PROJECT_ID=$(gcloud config get-value project)
+
+    echo ""
+    echo "📈 Dashboards:"
+    gcloud monitoring dashboards list --format="table(displayName,name)" --filter="displayName~'Cachet'" 2>/dev/null || echo "   (none)"
+
+    echo ""
+    echo "🚨 Alert Policies:"
+    gcloud alpha monitoring policies list --format="table(displayName,enabled,conditions.displayName)" --filter="displayName~'Cachet'" 2>/dev/null || echo "   (none)"
+
+    echo ""
+    echo "🔔 Notification Channels:"
+    gcloud alpha monitoring channels list --format="table(displayName,type)" 2>/dev/null || echo "   (none)"
+
+    echo ""
+    echo "🔗 Console: https://console.cloud.google.com/monitoring?project=$PROJECT_ID"
   '';
 
   # Service processes with automatic port allocation.

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -1,0 +1,95 @@
+# Monitoring
+
+Cachet uses GCP Cloud Monitoring for production observability. Metrics are exposed via Prometheus `/metrics` endpoints on each service, scraped by GCP Managed Prometheus.
+
+## Setup
+
+```bash
+devenv shell -- gcp:monitoring:setup    # Create dashboard + alert policies
+devenv shell -- gcp:monitoring:status   # Verify what's provisioned
+```
+
+Prerequisite: `gcp:setup` must have been run first (enables monitoring API).
+
+## Dashboard
+
+The **Cachet Operations** dashboard (`infra/monitoring/dashboard.json`) has four sections:
+
+### Service Health (Cloud Run built-in metrics)
+- **Request Rate by Service** — time series of req/s per service
+- **Error Rate (5xx)** — stacked area of server errors per service
+- **Latency (p50/p95/p99)** — response time percentiles
+- **Instance Count** — Cloud Run autoscaler activity
+
+### Verification & Issuance (Prometheus custom metrics)
+- **Verifications by Outcome** — pass/fail/error breakdown
+- **Verification Duration** — p50 and p95 histogram
+- **Credentials Issued** — issuance rate
+
+### Pack & Relay (Prometheus custom metrics)
+- **Pack Popularity** — which packs are requested most, by pack_id
+- **Relay Session Lifecycle** — created/completed session rates
+
+## Alert Policies
+
+Four alert policies are defined in `infra/monitoring/alerts.json`:
+
+| Alert | Condition | Window |
+|-------|-----------|--------|
+| **High Error Rate** | 5xx rate > 1% of total requests | 5 min |
+| **High Latency** | p95 > 2000ms | 5 min |
+| **Verification Failure Spike** | fail rate > 20% | 15 min |
+| **Service Down** | Zero requests received | 10 min |
+
+Alerts auto-close after 30 minutes (1 hour for verification spike).
+
+## Notification Channels
+
+Alert policies are created without notification channels. After running `gcp:monitoring:setup`, configure a channel in the GCP Console:
+
+1. Go to **Monitoring > Alerting > Notification channels**
+2. Add an email, Slack, or PagerDuty channel
+3. Edit each alert policy to add the channel
+
+## Custom Metrics
+
+These are the Prometheus metrics exposed by Cachet services on `/metrics`:
+
+### Verifier
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `cachet_verifications_total` | counter | pack_id, status | Verification outcomes |
+| `cachet_verifications_duration_seconds` | histogram | pack_id, status | Time to result |
+| `cachet_packs_requested` | counter | pack_id | Pack fetch requests |
+| `cachet_sessions_created` | counter | — | Verification sessions |
+
+### Relay
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `cachet_relay_sessions_total` | counter | status | Session lifecycle |
+| `cachet_relay_holder_response_time_seconds` | histogram | — | Holder response latency |
+
+### Issuance Gateway
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `cachet_credentials_issued` | counter | — | Credentials issued |
+| `cachet_webhooks_received` | counter | status | Veriff webhooks |
+| `cachet_webhooks_stored` | counter | — | Validated webhooks |
+| `cachet_quality_tier` | counter | tier | By quality tier |
+
+## Prometheus Scraping on Cloud Run
+
+GCP Managed Prometheus scrapes the `/metrics` endpoint automatically when configured. Add this annotation to Cloud Run service metadata:
+
+```yaml
+metadata:
+  annotations:
+    run.googleapis.com/launch-stage: BETA
+spec:
+  template:
+    metadata:
+      annotations:
+        run.googleapis.com/container-dependencies: '{"sidecar":["app"]}'
+```
+
+Or use the sidecar-less approach with Cloud Run Jobs for scraping. See [GCP documentation](https://cloud.google.com/run/docs/monitoring).

--- a/infra/monitoring/alerts.json
+++ b/infra/monitoring/alerts.json
@@ -1,0 +1,140 @@
+{
+  "policies": [
+    {
+      "displayName": "Cachet: High Error Rate (5xx > 1%)",
+      "documentation": {
+        "content": "One or more Cachet Cloud Run services are returning 5xx errors above 1% of total requests over a 5-minute window. Check service logs for root cause.",
+        "mimeType": "text/markdown"
+      },
+      "conditions": [
+        {
+          "displayName": "5xx rate > 1% on any Cloud Run service",
+          "conditionThreshold": {
+            "filter": "resource.type = \"cloud_run_revision\" AND resource.labels.service_name = monitoring.regex.full_match(\"cachet-.*\") AND metric.type = \"run.googleapis.com/request_count\" AND metric.labels.response_code_class = \"5xx\"",
+            "aggregations": [
+              {
+                "alignmentPeriod": "300s",
+                "perSeriesAligner": "ALIGN_RATE",
+                "crossSeriesReducer": "REDUCE_SUM",
+                "groupByFields": ["resource.labels.service_name"]
+              }
+            ],
+            "denominatorFilter": "resource.type = \"cloud_run_revision\" AND resource.labels.service_name = monitoring.regex.full_match(\"cachet-.*\") AND metric.type = \"run.googleapis.com/request_count\"",
+            "denominatorAggregations": [
+              {
+                "alignmentPeriod": "300s",
+                "perSeriesAligner": "ALIGN_RATE",
+                "crossSeriesReducer": "REDUCE_SUM",
+                "groupByFields": ["resource.labels.service_name"]
+              }
+            ],
+            "comparison": "COMPARISON_GT",
+            "thresholdValue": 0.01,
+            "duration": "300s",
+            "trigger": { "count": 1 }
+          }
+        }
+      ],
+      "combiner": "OR",
+      "alertStrategy": {
+        "autoClose": "1800s"
+      }
+    },
+    {
+      "displayName": "Cachet: High Latency (p95 > 2s)",
+      "documentation": {
+        "content": "A Cachet Cloud Run service has p95 latency exceeding 2 seconds. This may indicate resource contention, cold starts, or upstream dependency issues.",
+        "mimeType": "text/markdown"
+      },
+      "conditions": [
+        {
+          "displayName": "p95 latency > 2s on any Cloud Run service",
+          "conditionThreshold": {
+            "filter": "resource.type = \"cloud_run_revision\" AND resource.labels.service_name = monitoring.regex.full_match(\"cachet-.*\") AND metric.type = \"run.googleapis.com/request_latencies\"",
+            "aggregations": [
+              {
+                "alignmentPeriod": "300s",
+                "perSeriesAligner": "ALIGN_PERCENTILE_95",
+                "crossSeriesReducer": "REDUCE_MAX",
+                "groupByFields": ["resource.labels.service_name"]
+              }
+            ],
+            "comparison": "COMPARISON_GT",
+            "thresholdValue": 2000,
+            "duration": "300s",
+            "trigger": { "count": 1 }
+          }
+        }
+      ],
+      "combiner": "OR",
+      "alertStrategy": {
+        "autoClose": "1800s"
+      }
+    },
+    {
+      "displayName": "Cachet: Verification Failure Spike (>20% in 15min)",
+      "documentation": {
+        "content": "Verification failure rate jumped above 20% over a 15-minute window. This may indicate a revocation event, issuer key rotation, or credential format issue. Check verifier logs and the admin dashboard.",
+        "mimeType": "text/markdown"
+      },
+      "conditions": [
+        {
+          "displayName": "Verification fail rate > 20%",
+          "conditionThreshold": {
+            "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/cachet_verifications_total/counter\" AND metric.labels.status = \"fail\"",
+            "aggregations": [
+              {
+                "alignmentPeriod": "900s",
+                "perSeriesAligner": "ALIGN_RATE"
+              }
+            ],
+            "denominatorFilter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/cachet_verifications_total/counter\"",
+            "denominatorAggregations": [
+              {
+                "alignmentPeriod": "900s",
+                "perSeriesAligner": "ALIGN_RATE"
+              }
+            ],
+            "comparison": "COMPARISON_GT",
+            "thresholdValue": 0.2,
+            "duration": "900s",
+            "trigger": { "count": 1 }
+          }
+        }
+      ],
+      "combiner": "OR",
+      "alertStrategy": {
+        "autoClose": "3600s"
+      }
+    },
+    {
+      "displayName": "Cachet: Service Down (no requests for 10min)",
+      "documentation": {
+        "content": "A Cachet Cloud Run service has received zero requests for 10 minutes. This may indicate a deployment failure, routing issue, or the service being scaled to zero unexpectedly.",
+        "mimeType": "text/markdown"
+      },
+      "conditions": [
+        {
+          "displayName": "No requests for 10 minutes",
+          "conditionAbsent": {
+            "filter": "resource.type = \"cloud_run_revision\" AND resource.labels.service_name = monitoring.regex.full_match(\"cachet-.*\") AND metric.type = \"run.googleapis.com/request_count\"",
+            "aggregations": [
+              {
+                "alignmentPeriod": "300s",
+                "perSeriesAligner": "ALIGN_RATE",
+                "crossSeriesReducer": "REDUCE_SUM",
+                "groupByFields": ["resource.labels.service_name"]
+              }
+            ],
+            "duration": "600s",
+            "trigger": { "count": 1 }
+          }
+        }
+      ],
+      "combiner": "OR",
+      "alertStrategy": {
+        "autoClose": "1800s"
+      }
+    }
+  ]
+}

--- a/infra/monitoring/dashboard.json
+++ b/infra/monitoring/dashboard.json
@@ -1,0 +1,288 @@
+{
+  "displayName": "Cachet Operations",
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "xPos": 0, "yPos": 0, "width": 12, "height": 1,
+        "widget": {
+          "title": "Service Health",
+          "text": { "content": "## Service Health", "format": "MARKDOWN" }
+        }
+      },
+      {
+        "xPos": 0, "yPos": 1, "width": 6, "height": 4,
+        "widget": {
+          "title": "Request Rate by Service",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"cloud_run_revision\" AND resource.labels.service_name = monitoring.regex.full_match(\"cachet-.*\") AND metric.type = \"run.googleapis.com/request_count\"",
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_RATE",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": ["resource.labels.service_name"]
+                    }
+                  }
+                },
+                "plotType": "LINE"
+              }
+            ],
+            "yAxis": { "label": "req/s" }
+          }
+        }
+      },
+      {
+        "xPos": 6, "yPos": 1, "width": 6, "height": 4,
+        "widget": {
+          "title": "Error Rate by Service (5xx)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"cloud_run_revision\" AND resource.labels.service_name = monitoring.regex.full_match(\"cachet-.*\") AND metric.type = \"run.googleapis.com/request_count\" AND metric.labels.response_code_class = \"5xx\"",
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_RATE",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": ["resource.labels.service_name"]
+                    }
+                  }
+                },
+                "plotType": "STACKED_AREA"
+              }
+            ],
+            "yAxis": { "label": "errors/s" }
+          }
+        }
+      },
+      {
+        "xPos": 0, "yPos": 5, "width": 6, "height": 4,
+        "widget": {
+          "title": "p50 / p95 / p99 Latency (ms)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"cloud_run_revision\" AND resource.labels.service_name = monitoring.regex.full_match(\"cachet-.*\") AND metric.type = \"run.googleapis.com/request_latencies\"",
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_PERCENTILE_50",
+                      "crossSeriesReducer": "REDUCE_MAX",
+                      "groupByFields": ["resource.labels.service_name"]
+                    }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "${resource.labels.service_name} p50"
+              },
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"cloud_run_revision\" AND resource.labels.service_name = monitoring.regex.full_match(\"cachet-.*\") AND metric.type = \"run.googleapis.com/request_latencies\"",
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_PERCENTILE_95",
+                      "crossSeriesReducer": "REDUCE_MAX",
+                      "groupByFields": ["resource.labels.service_name"]
+                    }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "${resource.labels.service_name} p95"
+              },
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"cloud_run_revision\" AND resource.labels.service_name = monitoring.regex.full_match(\"cachet-.*\") AND metric.type = \"run.googleapis.com/request_latencies\"",
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_PERCENTILE_99",
+                      "crossSeriesReducer": "REDUCE_MAX",
+                      "groupByFields": ["resource.labels.service_name"]
+                    }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "${resource.labels.service_name} p99"
+              }
+            ],
+            "yAxis": { "label": "ms" }
+          }
+        }
+      },
+      {
+        "xPos": 6, "yPos": 5, "width": 6, "height": 4,
+        "widget": {
+          "title": "Instance Count by Service",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"cloud_run_revision\" AND resource.labels.service_name = monitoring.regex.full_match(\"cachet-.*\") AND metric.type = \"run.googleapis.com/container/instance_count\"",
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_MAX",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": ["resource.labels.service_name"]
+                    }
+                  }
+                },
+                "plotType": "STACKED_BAR"
+              }
+            ],
+            "yAxis": { "label": "instances" }
+          }
+        }
+      },
+      {
+        "xPos": 0, "yPos": 9, "width": 12, "height": 1,
+        "widget": {
+          "title": "Verification & Issuance",
+          "text": { "content": "## Verification & Issuance (Prometheus Metrics)", "format": "MARKDOWN" }
+        }
+      },
+      {
+        "xPos": 0, "yPos": 10, "width": 4, "height": 4,
+        "widget": {
+          "title": "Verifications by Outcome",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/cachet_verifications_total/counter\"",
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_RATE",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": ["metric.labels.status"]
+                    }
+                  }
+                },
+                "plotType": "STACKED_AREA"
+              }
+            ],
+            "yAxis": { "label": "verifications/s" }
+          }
+        }
+      },
+      {
+        "xPos": 4, "yPos": 10, "width": 4, "height": 4,
+        "widget": {
+          "title": "Verification Duration (p50/p95)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/cachet_verifications_duration_seconds/histogram\"",
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_PERCENTILE_50"
+                    }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "p50"
+              },
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/cachet_verifications_duration_seconds/histogram\"",
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_PERCENTILE_95"
+                    }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "p95"
+              }
+            ],
+            "yAxis": { "label": "seconds" }
+          }
+        }
+      },
+      {
+        "xPos": 8, "yPos": 10, "width": 4, "height": 4,
+        "widget": {
+          "title": "Credentials Issued",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/cachet_credentials_issued/counter\"",
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_RATE"
+                    }
+                  }
+                },
+                "plotType": "LINE"
+              }
+            ],
+            "yAxis": { "label": "credentials/s" }
+          }
+        }
+      },
+      {
+        "xPos": 0, "yPos": 14, "width": 6, "height": 4,
+        "widget": {
+          "title": "Pack Popularity (requests by pack_id)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/cachet_packs_requested/counter\"",
+                    "aggregation": {
+                      "alignmentPeriod": "300s",
+                      "perSeriesAligner": "ALIGN_RATE",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": ["metric.labels.pack_id"]
+                    }
+                  }
+                },
+                "plotType": "STACKED_BAR"
+              }
+            ],
+            "yAxis": { "label": "req/s" }
+          }
+        }
+      },
+      {
+        "xPos": 6, "yPos": 14, "width": 6, "height": 4,
+        "widget": {
+          "title": "Relay Session Lifecycle",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/cachet_relay_sessions_total/counter\"",
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_RATE",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": ["metric.labels.status"]
+                    }
+                  }
+                },
+                "plotType": "STACKED_AREA"
+              }
+            ],
+            "yAxis": { "label": "sessions/s" }
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Slice 9 — the final piece of #101 backoffice v1.0.

- **Dashboard**: "Cachet Operations" with 10 panels across 4 sections (service health, latency, verification outcomes, pack popularity, relay sessions, issuance rate)
- **Alert policies**: 4 policies (5xx error rate >1%, p95 latency >2s, verification failure spike >20%, service down for 10min)
- **Provisioning**: `gcp:monitoring:setup` and `gcp:monitoring:status` scripts following existing `gcp:*` pattern
- **Docs**: `docs/MONITORING.md` covering setup, dashboard panels, alert thresholds, custom metrics reference, and Prometheus scraping config

## Test plan

- [ ] `jq . infra/monitoring/alerts.json` — valid JSON
- [ ] `jq . infra/monitoring/dashboard.json` — valid JSON  
- [ ] `devenv shell` enters without errors (devenv.nix parses)
- [ ] After `gcp:setup` + `gcp:monitoring:setup`: dashboard visible in GCP Console, 4 alert policies created

🤖 Generated with [Claude Code](https://claude.com/claude-code)