### PR TITLE
feat: edge-to-edge migration for all screens

### DIFF
--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/MainActivity.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/MainActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -16,6 +17,7 @@ class MainActivity : ComponentActivity() {
     private val deepLinkUri = mutableStateOf<String?>(null)
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         val demoMode = intent.getBooleanExtra("demo_mode", false)
         val demoEmpty = intent.getBooleanExtra("demo_empty", false)

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/credentials/CachetDetailScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/credentials/CachetDetailScreen.kt
@@ -43,11 +43,11 @@ fun CachetDetailScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
+                .statusBarsPadding()
                 .padding(horizontal = 24.dp)
         ) {
             // ── Back button ──
             item {
-                Spacer(modifier = Modifier.height(48.dp))
                 IconButton(
                     onClick = onBack,
                     modifier = Modifier.offset(x = (-12).dp)
@@ -248,6 +248,13 @@ fun CachetDetailScreen(
                     )
                     Spacer(modifier = Modifier.height(32.dp))
                 }
+            }
+
+            // ── Bottom safe area ──
+            item {
+                Spacer(modifier = Modifier
+                    .navigationBarsPadding()
+                    .height(8.dp))
             }
         }
     }

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/theme/Theme.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/theme/Theme.kt
@@ -2,7 +2,6 @@ package id.cachet.wallet.android.ui.theme
 
 import android.app.Activity
 import android.os.Build
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
@@ -10,7 +9,6 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
@@ -78,7 +76,9 @@ private val DarkColorScheme = darkColorScheme(
 
 @Composable
 fun CachetWalletTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
+    // Force light theme — screens use hardcoded light-only color tokens
+    // (SurfaceBackground, TextPrimary, etc.) so dark mode is not yet supported.
+    darkTheme: Boolean = false,
     dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
@@ -94,8 +94,9 @@ fun CachetWalletTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.background.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+            val controller = WindowCompat.getInsetsController(window, view)
+            controller.isAppearanceLightStatusBars = !darkTheme
+            controller.isAppearanceLightNavigationBars = !darkTheme
         }
     }
 

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/CachetResultScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/CachetResultScreen.kt
@@ -41,6 +41,7 @@ fun CachetResultScreen(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
+                    .statusBarsPadding()
                     .padding(horizontal = 24.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
@@ -88,7 +89,9 @@ fun CachetResultScreen(
                     containerColor = Color.White,
                     contentColor = BrandPrimary
                 )
-                Spacer(modifier = Modifier.height(24.dp))
+                Spacer(modifier = Modifier
+                    .navigationBarsPadding()
+                    .height(8.dp))
             }
         }
         return
@@ -103,6 +106,7 @@ fun CachetResultScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
+                .statusBarsPadding()
                 .padding(horizontal = 24.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -292,7 +296,9 @@ fun CachetResultScreen(
                     containerColor = Color.White,
                     contentColor = BrandPrimary
                 )
-                Spacer(modifier = Modifier.height(24.dp))
+                Spacer(modifier = Modifier
+                    .navigationBarsPadding()
+                    .height(8.dp))
             }
         }
     }

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/DeepLinkExpiredScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/DeepLinkExpiredScreen.kt
@@ -29,6 +29,7 @@ fun DeepLinkExpiredScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .statusBarsPadding()
                 .padding(horizontal = 24.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -47,8 +48,6 @@ fun DeepLinkExpiredScreen(
                     )
                 }
             }
-
-            Spacer(modifier = Modifier.height(48.dp))
 
             // Cachet shield (full color, never greyed)
             CachetMark(type = cachetType, size = 80.dp)
@@ -134,7 +133,9 @@ fun DeepLinkExpiredScreen(
                 )
             }
 
-            Spacer(modifier = Modifier.height(32.dp))
+            Spacer(modifier = Modifier
+                .navigationBarsPadding()
+                .height(8.dp))
         }
     }
 }

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/IncomingRequestScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/IncomingRequestScreen.kt
@@ -41,6 +41,7 @@ fun IncomingRequestScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .statusBarsPadding()
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
@@ -292,6 +293,10 @@ fun IncomingRequestScreen(
                 }
                 Spacer(modifier = Modifier.height(16.dp))
             }
+
+            Spacer(modifier = Modifier
+                .navigationBarsPadding()
+                .height(8.dp))
         }
     }
 }

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/PackPickerScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/PackPickerScreen.kt
@@ -49,6 +49,7 @@ fun PackPickerScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
+                .statusBarsPadding()
                 .padding(horizontal = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -160,6 +161,13 @@ fun PackPickerScreen(
                     textAlign = TextAlign.Center,
                     modifier = Modifier.fillMaxWidth()
                 )
+            }
+
+            // ── Bottom safe area ──
+            item {
+                Spacer(modifier = Modifier
+                    .navigationBarsPadding()
+                    .height(8.dp))
             }
         }
     }

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/QrScannerScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/QrScannerScreen.kt
@@ -85,9 +85,8 @@ fun QrScannerScreen(
         color = Color(0xFF0F0F0F)
     ) {
         Box(modifier = Modifier.fillMaxSize().testTag("qr_scanner_screen")) {
-            Column(modifier = Modifier.fillMaxSize()) {
+            Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
                 // ── Header ──
-                Spacer(modifier = Modifier.height(48.dp))
                 Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp)) {
                     Text(
                         text = "Scan to verify",
@@ -221,7 +220,9 @@ fun QrScannerScreen(
                     )
                 }
 
-                Spacer(modifier = Modifier.height(32.dp))
+                Spacer(modifier = Modifier
+                    .navigationBarsPadding()
+                    .height(8.dp))
             }
         }
     }

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/QrShareScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/QrShareScreen.kt
@@ -62,6 +62,7 @@ fun QrShareScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .statusBarsPadding()
                 .padding(horizontal = 24.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -69,7 +70,7 @@ fun QrShareScreen(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 16.dp),
+                    .padding(top = 8.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -249,7 +250,9 @@ fun QrShareScreen(
                 )
             }
 
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier
+                .navigationBarsPadding()
+                .height(8.dp))
         }
     }
 }


### PR DESCRIPTION
## Summary
- Enable `enableEdgeToEdge()` in MainActivity for transparent system bars and proper inset handling
- Replace hardcoded 48dp status bar spacers with `statusBarsPadding()` + `navigationBarsPadding()` across all overlay screens (QrScanner, CachetDetail, DeepLinkExpired, QrShare, IncomingRequest, PackPicker, CachetResult)
- Force light theme — screens use hardcoded light-only color tokens, so dark mode caused illegible text on Samsung S24 Ultra
- Scaffold-hosted screens (Home, Activity) handled automatically via `innerPadding`

## Test plan
- [x] `assembleDebug` builds clean
- [x] 79/80 BDD scenarios pass (1 pre-existing failure in liveness skip scenario — tracked in #127)
- [x] Verified on Samsung S24 Ultra (gesture nav, dark mode enabled)
- [x] Verified on Pixel emulator (3-button nav)
- [ ] CI passes

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)