### PR TITLE
feat: offline-first cache layer + local SD-JWT verification

### DIFF
--- a/mobile/androidApp/src/main/assets/packs/childcare-readiness.base.json
+++ b/mobile/androidApp/src/main/assets/packs/childcare-readiness.base.json
@@ -1,0 +1,55 @@
+{
+  "id": "pack.childcare.readiness",
+  "version": "0.1.0",
+  "name": "Childcare Readiness",
+  "purpose": "Assess suitability for paid childcare work in private homes",
+  "jurisdictions": ["EU"],
+  "badge": {
+    "label": "Childcare‑Ready (EU)",
+    "ttl": "P90D",
+    "jurisdiction": "EU"
+  },
+  "predicates": [
+    {
+      "id": "age.ge.18",
+      "claim": "age",
+      "operator": ">=",
+      "value": 18,
+      "issuersAccepted": ["did:veriff:*"],
+      "proofType": "sd-jwt"
+    },
+    {
+      "id": "identity.verified",
+      "claim": "verified",
+      "operator": "boolean",
+      "value": true,
+      "issuersAccepted": ["did:veriff:*"],
+      "proofType": "sd-jwt"
+    },
+    {
+      "id": "criminal.clear",
+      "claim": "criminal_record_clear",
+      "operator": "boolean",
+      "value": true,
+      "issuersAccepted": ["did:checks:*-eu"],
+      "proofType": "vc-bbs"
+    },
+    {
+      "id": "firstaid.valid",
+      "claim": "first_aid_cert_valid",
+      "operator": "boolean",
+      "value": true,
+      "issuersAccepted": ["did:edu:*", "did:cert:*"],
+      "proofType": "vc-bbs",
+      "required": false
+    },
+    {
+      "id": "references.verified",
+      "claim": "references_count",
+      "operator": ">=",
+      "value": 2,
+      "issuersAccepted": ["did:cachet:vouch"],
+      "proofType": "zk-snark"
+    }
+  ]
+}

--- a/mobile/androidApp/src/main/assets/packs/childcare-readiness.ee.json
+++ b/mobile/androidApp/src/main/assets/packs/childcare-readiness.ee.json
@@ -1,0 +1,55 @@
+{
+  "id": "pack.childcare.readiness.ee",
+  "version": "0.1.0",
+  "name": "Childcare Readiness (Estonia)",
+  "purpose": "Assess suitability for paid childcare work in private homes",
+  "jurisdictions": ["EE"],
+  "badge": {
+    "label": "Childcare‑Ready (EE)",
+    "ttl": "P90D",
+    "jurisdiction": "EE"
+  },
+  "predicates": [
+    {
+      "id": "age.ge.18",
+      "claim": "age",
+      "operator": ">=",
+      "value": 18,
+      "issuersAccepted": ["did:veriff:*"],
+      "proofType": "sd-jwt"
+    },
+    {
+      "id": "identity.verified",
+      "claim": "verified",
+      "operator": "boolean",
+      "value": true,
+      "issuersAccepted": ["did:veriff:*"],
+      "proofType": "sd-jwt"
+    },
+    {
+      "id": "criminal.clear.ee",
+      "claim": "criminal_record_clear",
+      "operator": "boolean",
+      "value": true,
+      "issuersAccepted": ["did:e-gov:ee:justice"],
+      "proofType": "vc-bbs"
+    },
+    {
+      "id": "firstaid.valid.ee",
+      "claim": "first_aid_cert_valid",
+      "operator": "boolean",
+      "value": true,
+      "issuersAccepted": ["did:redcross:ee"],
+      "proofType": "vc-bbs",
+      "required": false
+    },
+    {
+      "id": "references.verified",
+      "claim": "references_count",
+      "operator": ">=",
+      "value": 2,
+      "issuersAccepted": ["did:cachet:vouch"],
+      "proofType": "zk-snark"
+    }
+  ]
+}

--- a/mobile/androidApp/src/main/assets/packs/childcare-readiness.es.json
+++ b/mobile/androidApp/src/main/assets/packs/childcare-readiness.es.json
@@ -1,0 +1,55 @@
+{
+  "id": "pack.childcare.readiness.es",
+  "version": "0.1.0",
+  "name": "Childcare Readiness (Spain)",
+  "purpose": "Assess suitability for paid childcare work in private homes",
+  "jurisdictions": ["ES"],
+  "badge": {
+    "label": "Childcare‑Ready (ES)",
+    "ttl": "P90D",
+    "jurisdiction": "ES"
+  },
+  "predicates": [
+    {
+      "id": "age.ge.18",
+      "claim": "age",
+      "operator": ">=",
+      "value": 18,
+      "issuersAccepted": ["did:veriff:*"],
+      "proofType": "sd-jwt"
+    },
+    {
+      "id": "identity.verified",
+      "claim": "verified",
+      "operator": "boolean",
+      "value": true,
+      "issuersAccepted": ["did:veriff:*"],
+      "proofType": "sd-jwt"
+    },
+    {
+      "id": "criminal.clear.es",
+      "claim": "sexual_offences_clear",
+      "operator": "boolean",
+      "value": true,
+      "issuersAccepted": ["did:justice:es"],
+      "proofType": "vc-bbs"
+    },
+    {
+      "id": "firstaid.valid.es",
+      "claim": "first_aid_cert_valid",
+      "operator": "boolean",
+      "value": true,
+      "issuersAccepted": ["did:redcross:es"],
+      "proofType": "vc-bbs",
+      "required": false
+    },
+    {
+      "id": "references.verified",
+      "claim": "references_count",
+      "operator": ">=",
+      "value": 2,
+      "issuersAccepted": ["did:cachet:vouch"],
+      "proofType": "zk-snark"
+    }
+  ]
+}

--- a/mobile/androidApp/src/main/assets/packs/childcare-readiness.fr.json
+++ b/mobile/androidApp/src/main/assets/packs/childcare-readiness.fr.json
@@ -1,0 +1,55 @@
+{
+  "id": "pack.childcare.readiness.fr",
+  "version": "0.1.0",
+  "name": "Childcare Readiness (France)",
+  "purpose": "Assess suitability for paid childcare work in private homes",
+  "jurisdictions": ["FR"],
+  "badge": {
+    "label": "Childcare‑Ready (FR)",
+    "ttl": "P90D",
+    "jurisdiction": "FR"
+  },
+  "predicates": [
+    {
+      "id": "age.ge.18",
+      "claim": "age",
+      "operator": ">=",
+      "value": 18,
+      "issuersAccepted": ["did:veriff:*"],
+      "proofType": "sd-jwt"
+    },
+    {
+      "id": "identity.verified",
+      "claim": "verified",
+      "operator": "boolean",
+      "value": true,
+      "issuersAccepted": ["did:veriff:*"],
+      "proofType": "sd-jwt"
+    },
+    {
+      "id": "criminal.clear.fr",
+      "claim": "casier_b3_clear",
+      "operator": "boolean",
+      "value": true,
+      "issuersAccepted": ["did:justice:fr"],
+      "proofType": "vc-bbs"
+    },
+    {
+      "id": "firstaid.valid.fr",
+      "claim": "first_aid_cert_valid",
+      "operator": "boolean",
+      "value": true,
+      "issuersAccepted": ["did:croixrouge:fr"],
+      "proofType": "vc-bbs",
+      "required": false
+    },
+    {
+      "id": "references.verified",
+      "claim": "references_count",
+      "operator": ">=",
+      "value": 2,
+      "issuersAccepted": ["did:cachet:vouch"],
+      "proofType": "zk-snark"
+    }
+  ]
+}

--- a/mobile/androidApp/src/main/assets/packs/identity-basic.json
+++ b/mobile/androidApp/src/main/assets/packs/identity-basic.json
@@ -1,0 +1,38 @@
+{
+  "id": "pack.identity.basic",
+  "version": "0.1.0",
+  "name": "Identity Verification",
+  "purpose": "Verify core identity attributes: age, document authenticity, liveness",
+  "jurisdictions": ["GLOBAL"],
+  "badge": {
+    "label": "Identity Verified",
+    "ttl": "P180D",
+    "jurisdiction": "GLOBAL"
+  },
+  "predicates": [
+    {
+      "id": "age.ge.18",
+      "claim": "age",
+      "operator": ">=",
+      "value": 18,
+      "issuersAccepted": ["did:veriff:*"],
+      "proofType": "sd-jwt"
+    },
+    {
+      "id": "identity.verified",
+      "claim": "verified",
+      "operator": "boolean",
+      "value": true,
+      "issuersAccepted": ["did:veriff:*"],
+      "proofType": "sd-jwt"
+    },
+    {
+      "id": "liveness.verified",
+      "claim": "liveness_verified",
+      "operator": "boolean",
+      "value": true,
+      "issuersAccepted": ["did:veriff:*"],
+      "proofType": "sd-jwt"
+    }
+  ]
+}

--- a/mobile/androidApp/src/main/assets/packs/safe-seller.base.json
+++ b/mobile/androidApp/src/main/assets/packs/safe-seller.base.json
@@ -1,0 +1,47 @@
+{
+  "id": "pack.safe.seller",
+  "version": "0.1.0",
+  "name": "Safe Seller",
+  "purpose": "Reduce counterparty and fraud risk in peer-to-peer sales",
+  "jurisdictions": ["EU"],
+  "badge": {
+    "label": "Safe Seller (EU)",
+    "ttl": "P60D",
+    "jurisdiction": "EU"
+  },
+  "predicates": [
+    {
+      "id": "identity.verified",
+      "claim": "verified",
+      "operator": "boolean",
+      "value": true,
+      "issuersAccepted": ["did:veriff:*"],
+      "proofType": "sd-jwt"
+    },
+    {
+      "id": "platform.tenure",
+      "claim": "platform_tenure_months_max",
+      "operator": ">=",
+      "value": 6,
+      "issuersAccepted": ["did:platform:*"],
+      "proofType": "zk-snark"
+    },
+    {
+      "id": "platform.fulfilment",
+      "claim": "fulfilment_rate",
+      "operator": ">=",
+      "value": 0.95,
+      "issuersAccepted": ["did:platform:*"],
+      "proofType": "zk-snark"
+    },
+    {
+      "id": "chargeback.risk.low",
+      "claim": "chargeback_ratio",
+      "operator": "<",
+      "value": 0.01,
+      "issuersAccepted": ["did:payments:*"],
+      "proofType": "vc-bbs",
+      "required": false
+    }
+  ]
+}

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/di/AndroidModule.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/di/AndroidModule.kt
@@ -8,6 +8,7 @@ import id.cachet.wallet.android.ui.WalletViewModel
 import id.cachet.wallet.android.BuildConfig
 import id.cachet.wallet.android.verification.VeriffService
 import id.cachet.wallet.db.WalletDatabase
+import id.cachet.wallet.domain.cache.BundledPackLoader
 import id.cachet.wallet.domain.crypto.AndroidKeyStoreKeyManager
 import id.cachet.wallet.domain.crypto.KeyManager
 import id.cachet.wallet.domain.repository.CredentialRepository
@@ -40,6 +41,9 @@ val androidModule = module {
     
     // Key management (hardware-backed Android KeyStore)
     single<KeyManager> { AndroidKeyStoreKeyManager() }
+
+    // Bundled pack definitions from assets
+    single { BundledPackLoader(androidContext()) }
 
     // Verification — demo uses MockVeriffService, prod uses NoOpVeriffService (until real SDK)
     single<VeriffService> {

--- a/mobile/shared/build.gradle.kts
+++ b/mobile/shared/build.gradle.kts
@@ -67,7 +67,7 @@ sqldelight {
     databases {
         create("WalletDatabase") {
             packageName.set("id.cachet.wallet.db")
-            version = 2
+            version = 4
             srcDirs("src/commonMain/sqldelight")
         }
     }

--- a/mobile/shared/src/androidMain/kotlin/id/cachet/wallet/domain/cache/BundledPackLoader.android.kt
+++ b/mobile/shared/src/androidMain/kotlin/id/cachet/wallet/domain/cache/BundledPackLoader.android.kt
@@ -1,0 +1,24 @@
+package id.cachet.wallet.domain.cache
+
+import android.content.Context
+import id.cachet.wallet.domain.model.PackDefinition
+import kotlinx.serialization.json.Json
+
+actual class BundledPackLoader(private val context: Context) {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    actual fun loadBundledPacks(): List<PackDefinition> {
+        val assetFiles = context.assets.list("packs") ?: return emptyList()
+        return assetFiles
+            .filter { it.endsWith(".json") }
+            .mapNotNull { filename ->
+                try {
+                    val content = context.assets.open("packs/$filename").bufferedReader().use { it.readText() }
+                    json.decodeFromString<PackDefinition>(content)
+                } catch (e: Exception) {
+                    null
+                }
+            }
+    }
+}

--- a/mobile/shared/src/androidMain/kotlin/id/cachet/wallet/domain/cache/GzipDecompressor.android.kt
+++ b/mobile/shared/src/androidMain/kotlin/id/cachet/wallet/domain/cache/GzipDecompressor.android.kt
@@ -1,0 +1,8 @@
+package id.cachet.wallet.domain.cache
+
+import java.io.ByteArrayInputStream
+import java.util.zip.GZIPInputStream
+
+actual fun gzipDecompress(compressed: ByteArray): ByteArray {
+    return GZIPInputStream(ByteArrayInputStream(compressed)).use { it.readBytes() }
+}

--- a/mobile/shared/src/androidMain/kotlin/id/cachet/wallet/domain/crypto/JWSVerifier.android.kt
+++ b/mobile/shared/src/androidMain/kotlin/id/cachet/wallet/domain/crypto/JWSVerifier.android.kt
@@ -8,12 +8,18 @@ import com.nimbusds.jose.jwk.ECKey
 actual class JWSVerifier actual constructor() {
 
     actual fun verify(jwsCompact: String, publicKeyJWK: String): String {
+        return verifyJWS(jwsCompact, publicKeyJWK, "oauth-authz-req+jwt")
+    }
+
+    actual fun verifyJWS(jwsCompact: String, publicKeyJWK: String, expectedTyp: String?): String {
         val jwsObject = JWSObject.parse(jwsCompact)
 
-        // Verify typ header
-        val typ = jwsObject.header.type?.type
-        if (typ != null && typ != "oauth-authz-req+jwt") {
-            throw SecurityException("Invalid JWS typ: expected oauth-authz-req+jwt, got $typ")
+        // Verify typ header if expected
+        if (expectedTyp != null) {
+            val typ = jwsObject.header.type?.type
+            if (typ != null && typ != expectedTyp) {
+                throw SecurityException("Invalid JWS typ: expected $expectedTyp, got $typ")
+            }
         }
 
         // Verify algorithm
@@ -28,11 +34,11 @@ actual class JWSVerifier actual constructor() {
             throw SecurityException("JWS signature verification failed")
         }
 
-        // Verify expiration
+        // Verify expiration (only for tokens that have exp)
         val payload = jwsObject.payload.toJSONObject()
         val exp = (payload["exp"] as? Number)?.toLong()
         if (exp != null && exp < System.currentTimeMillis() / 1000) {
-            throw SecurityException("Request Object has expired")
+            throw SecurityException("Token has expired")
         }
 
         return jwsObject.payload.toString()

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/cache/BundledPackLoader.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/cache/BundledPackLoader.kt
@@ -1,0 +1,11 @@
+package id.cachet.wallet.domain.cache
+
+import id.cachet.wallet.domain.model.PackDefinition
+
+/**
+ * Platform-specific loader for pack definitions bundled as app assets.
+ * These serve as the last-resort fallback when both cache and network are unavailable.
+ */
+expect class BundledPackLoader {
+    fun loadBundledPacks(): List<PackDefinition>
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/cache/CachedDIDResolver.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/cache/CachedDIDResolver.kt
@@ -1,0 +1,50 @@
+package id.cachet.wallet.domain.cache
+
+import id.cachet.wallet.domain.crypto.DIDResolver
+import id.cachet.wallet.domain.repository.DIDDocumentRepository
+import kotlin.time.Clock
+
+/**
+ * Caching decorator around [DIDResolver].
+ *
+ * Checks SQLite cache first (24h TTL). On cache miss or expiry,
+ * delegates to the network resolver and stores the result.
+ * On network failure with a stale cache entry, returns the stale value.
+ */
+class CachedDIDResolver(
+    private val delegate: DIDResolver,
+    private val repository: DIDDocumentRepository,
+    private val clock: Clock = Clock.System
+) {
+    companion object {
+        const val TTL_MS = 24 * 60 * 60 * 1000L // 24h
+    }
+
+    suspend fun resolvePublicKeyJWK(did: String, kid: String? = null): String {
+        // Check cache
+        val cached = repository.getDocument(did).getOrNull()
+        if (cached != null && !isExpired(cached.fetchedAt)) {
+            return DIDResolver.extractPublicKeyJWK(cached.documentJson, did, kid)
+        }
+
+        // Cache miss or expired — try network
+        return try {
+            val documentJson = delegate.resolveDocument(did)
+            val now = clock.now().toEpochMilliseconds()
+            repository.storeDocument(did, documentJson, now)
+            DIDResolver.extractPublicKeyJWK(documentJson, did, kid)
+        } catch (e: Exception) {
+            // Network failed — use stale cache if available
+            if (cached != null) {
+                DIDResolver.extractPublicKeyJWK(cached.documentJson, did, kid)
+            } else {
+                throw e
+            }
+        }
+    }
+
+    private fun isExpired(fetchedAtMs: Long): Boolean {
+        val now = clock.now().toEpochMilliseconds()
+        return (now - fetchedAtMs) > TTL_MS
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/cache/GzipDecompressor.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/cache/GzipDecompressor.kt
@@ -1,0 +1,6 @@
+package id.cachet.wallet.domain.cache
+
+/**
+ * Platform-specific gzip decompression for StatusList2021 bitstrings.
+ */
+expect fun gzipDecompress(compressed: ByteArray): ByteArray

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/cache/PackDefinitionCache.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/cache/PackDefinitionCache.kt
@@ -1,0 +1,61 @@
+package id.cachet.wallet.domain.cache
+
+import id.cachet.wallet.domain.model.PackDefinition
+import id.cachet.wallet.domain.repository.PackDefinitionRepository
+import kotlin.time.Clock
+
+/**
+ * Cache-aside orchestrator for pack definitions.
+ *
+ * Resolution order:
+ * 1. SQLite cache (if fresh within [STALE_THRESHOLD_MS])
+ * 2. Bundled pack assets (always available as fallback)
+ *
+ * On first access or when stale, the cache is seeded/refreshed from bundled assets.
+ * Network-fetched full pack definitions are not yet available (backend only serves
+ * summaries to mobile); this will be added when the registry exposes a full-pack endpoint.
+ */
+class PackDefinitionCache(
+    private val repository: PackDefinitionRepository,
+    private val loadBundled: () -> List<PackDefinition>,
+    private val clock: Clock = Clock.System
+) {
+    companion object {
+        const val STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000L // 24h
+    }
+
+    suspend fun getAllPacks(): List<PackDefinition> {
+        val cached = repository.getAllPacks().getOrNull()
+        if (!cached.isNullOrEmpty()) {
+            val fetchedAt = repository.getLatestFetchedAt().getOrNull()
+            if (fetchedAt != null && !isStale(fetchedAt)) {
+                return cached
+            }
+        }
+        // Cache empty or stale — seed from bundled assets
+        return seedFromBundled()
+    }
+
+    suspend fun getPackById(packId: String): PackDefinition? {
+        val cached = repository.getPackById(packId).getOrNull()
+        if (cached != null) {
+            return cached
+        }
+        // Try seeding from bundled if cache is empty
+        seedFromBundled()
+        return repository.getPackById(packId).getOrNull()
+    }
+
+    suspend fun seedFromBundled(): List<PackDefinition> {
+        val bundled = loadBundled()
+        if (bundled.isNotEmpty()) {
+            repository.storeAll(bundled)
+        }
+        return bundled
+    }
+
+    private fun isStale(fetchedAtMs: Long): Boolean {
+        val now = clock.now().toEpochMilliseconds()
+        return (now - fetchedAtMs) > STALE_THRESHOLD_MS
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/cache/StatusListCache.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/cache/StatusListCache.kt
@@ -1,0 +1,82 @@
+package id.cachet.wallet.domain.cache
+
+import id.cachet.wallet.domain.crypto.Base64Url
+import id.cachet.wallet.domain.repository.StatusListRepository
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import kotlin.time.Clock
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Fetches, caches, and checks StatusList2021 bitstrings for credential revocation.
+ *
+ * Cache hierarchy:
+ * 1. SQLite (5-min TTL per spec)
+ * 2. HTTP fetch from status list URL
+ *
+ * On network failure with a cached entry, returns stale cache (best-effort).
+ */
+class StatusListCache(
+    private val repository: StatusListRepository,
+    private val httpClient: HttpClient,
+    private val clock: Clock = Clock.System
+) {
+    companion object {
+        const val TTL_MS = 5 * 60 * 1000L // 5 minutes per spec
+    }
+
+    @Serializable
+    private data class StatusListCredential(val encodedList: String)
+
+    /**
+     * Check if a credential at [index] is revoked in the status list at [statusListUrl].
+     * Returns null if the status list cannot be fetched and no cache exists.
+     */
+    suspend fun isRevoked(statusListUrl: String, index: Int): Boolean? {
+        val bits = getBits(statusListUrl) ?: return null
+        val byteIdx = index / 8
+        val bitIdx = 7 - (index % 8) // MSB first per W3C spec
+        if (byteIdx >= bits.size) return null
+        return (bits[byteIdx].toInt() shr bitIdx) and 1 == 1
+    }
+
+    private suspend fun getBits(url: String): ByteArray? {
+        val cached = repository.getStatusList(url).getOrNull()
+        if (cached != null && !isExpired(cached.fetchedAt)) {
+            return decodeBitstring(cached.encodedList)
+        }
+
+        return try {
+            val encodedList = fetchEncodedList(url)
+            val now = clock.now().toEpochMilliseconds()
+            repository.storeStatusList(url, encodedList, now)
+            decodeBitstring(encodedList)
+        } catch (e: Exception) {
+            // Network failed — use stale cache if available
+            if (cached != null) decodeBitstring(cached.encodedList) else null
+        }
+    }
+
+    private suspend fun fetchEncodedList(url: String): String {
+        val responseText: String = httpClient.get(url).body()
+        val credential = Json.decodeFromString<StatusListCredential>(responseText)
+        return credential.encodedList
+    }
+
+    private fun decodeBitstring(encoded: String): ByteArray? {
+        return try {
+            val compressed = Base64Url.decode(encoded)
+            gzipDecompress(compressed)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun isExpired(fetchedAtMs: Long): Boolean {
+        val now = clock.now().toEpochMilliseconds()
+        return (now - fetchedAtMs) > TTL_MS
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/crypto/Base64Url.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/crypto/Base64Url.kt
@@ -1,0 +1,63 @@
+package id.cachet.wallet.domain.crypto
+
+/**
+ * Multiplatform base64url encode/decode utility.
+ * Consolidates the four separate implementations previously scattered across
+ * KBJWTBuilder, SDJWTParser, VerificationUseCase, and StatusListCache.
+ */
+object Base64Url {
+
+    private const val TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+    fun encode(bytes: ByteArray): String {
+        val sb = StringBuilder()
+        var i = 0
+        while (i < bytes.size) {
+            val b0 = bytes[i].toInt() and 0xFF
+            val b1 = if (i + 1 < bytes.size) bytes[i + 1].toInt() and 0xFF else 0
+            val b2 = if (i + 2 < bytes.size) bytes[i + 2].toInt() and 0xFF else 0
+            val remaining = bytes.size - i
+
+            sb.append(TABLE[b0 shr 2])
+            sb.append(TABLE[((b0 and 0x03) shl 4) or (b1 shr 4)])
+            if (remaining > 1) sb.append(TABLE[((b1 and 0x0F) shl 2) or (b2 shr 6)]) else sb.append('=')
+            if (remaining > 2) sb.append(TABLE[b2 and 0x3F]) else sb.append('=')
+            i += 3
+        }
+        return sb.toString()
+            .replace('+', '-')
+            .replace('/', '_')
+            .trimEnd('=')
+    }
+
+    fun decode(input: String): ByteArray {
+        val padded = input
+            .replace('-', '+')
+            .replace('_', '/')
+            .let { s ->
+                when (s.length % 4) {
+                    2 -> "$s=="
+                    3 -> "$s="
+                    else -> s
+                }
+            }
+        return decodeStandard(padded)
+    }
+
+    private fun decodeStandard(input: String): ByteArray {
+        val result = mutableListOf<Byte>()
+        var i = 0
+        while (i < input.length) {
+            val c0 = TABLE.indexOf(input[i])
+            val c1 = if (i + 1 < input.length) TABLE.indexOf(input[i + 1]) else 0
+            val c2 = if (i + 2 < input.length && input[i + 2] != '=') TABLE.indexOf(input[i + 2]) else -1
+            val c3 = if (i + 3 < input.length && input[i + 3] != '=') TABLE.indexOf(input[i + 3]) else -1
+
+            result.add(((c0 shl 2) or (c1 shr 4)).toByte())
+            if (c2 >= 0) result.add((((c1 and 0x0F) shl 4) or (c2 shr 2)).toByte())
+            if (c3 >= 0) result.add((((c2 and 0x03) shl 6) or c3).toByte())
+            i += 4
+        }
+        return result.toByteArray()
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/crypto/DIDResolver.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/crypto/DIDResolver.kt
@@ -20,7 +20,10 @@ class DIDResolver(private val httpClient: HttpClient) {
      * @param kid The key ID to look up (e.g., "did:web:verifier.cachet.id#key-1"). Defaults to did#key-1.
      * @return The public key as a JWK JSON string
      */
-    suspend fun resolvePublicKeyJWK(did: String, kid: String? = null): String {
+    /**
+     * Resolve a did:web DID document as raw JSON.
+     */
+    suspend fun resolveDocument(did: String): String {
         require(did.startsWith("did:web:")) { "Only did:web is supported, got: $did" }
 
         val hostPort = did.removePrefix("did:web:").replace("%3A", ":")
@@ -28,18 +31,30 @@ class DIDResolver(private val httpClient: HttpClient) {
         val scheme = if (hostPort.contains(":") || hostPort.startsWith("10.") || hostPort.startsWith("localhost")) "http" else "https"
         val url = "$scheme://$hostPort/.well-known/did.json"
 
-        val responseText: String = httpClient.get(url).body()
-        val doc = Json.parseToJsonElement(responseText).jsonObject
+        return httpClient.get(url).body()
+    }
 
-        val methods = doc["verificationMethod"]?.jsonArray
-            ?: throw Exception("No verificationMethod in DID document from $url")
+    suspend fun resolvePublicKeyJWK(did: String, kid: String? = null): String {
+        val responseText = resolveDocument(did)
+        return extractPublicKeyJWK(responseText, did, kid)
+    }
 
-        val targetKid = kid ?: "$did#key-1"
-        val method = methods.firstOrNull {
-            it.jsonObject["id"]?.jsonPrimitive?.content == targetKid
-        } ?: throw Exception("Key $targetKid not found in DID document")
+    companion object {
+        /**
+         * Extract a public key JWK from a DID document JSON string.
+         */
+        fun extractPublicKeyJWK(documentJson: String, did: String, kid: String? = null): String {
+            val doc = Json.parseToJsonElement(documentJson).jsonObject
+            val methods = doc["verificationMethod"]?.jsonArray
+                ?: throw Exception("No verificationMethod in DID document for $did")
 
-        return method.jsonObject["publicKeyJwk"]?.toString()
-            ?: throw Exception("No publicKeyJwk in verification method $targetKid")
+            val targetKid = kid ?: "$did#key-1"
+            val method = methods.firstOrNull {
+                it.jsonObject["id"]?.jsonPrimitive?.content == targetKid
+            } ?: throw Exception("Key $targetKid not found in DID document")
+
+            return method.jsonObject["publicKeyJwk"]?.toString()
+                ?: throw Exception("No publicKeyJwk in verification method $targetKid")
+        }
     }
 }

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/crypto/JWSVerifier.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/crypto/JWSVerifier.kt
@@ -9,6 +9,7 @@ package id.cachet.wallet.domain.crypto
 expect class JWSVerifier() {
     /**
      * Verify a JWS compact serialization and extract the payload.
+     * Checks for `oauth-authz-req+jwt` typ header (Request Object verification).
      *
      * @param jwsCompact The JWS string (header.payload.signature)
      * @param publicKeyJWK The verifier's public key as a JWK JSON string
@@ -16,4 +17,16 @@ expect class JWSVerifier() {
      * @throws SecurityException if the signature is invalid or the token is expired
      */
     fun verify(jwsCompact: String, publicKeyJWK: String): String
+
+    /**
+     * General-purpose JWS verification with configurable typ check.
+     * Used by the local verifier for issuer JWTs (typ=vc+sd-jwt) and KB-JWTs (typ=kb+jwt).
+     *
+     * @param jwsCompact The JWS string (header.payload.signature)
+     * @param publicKeyJWK The signer's public key as a JWK JSON string
+     * @param expectedTyp Expected typ header value (null to skip typ check)
+     * @return The verified payload as a JSON string
+     * @throws SecurityException if the signature is invalid
+     */
+    fun verifyJWS(jwsCompact: String, publicKeyJWK: String, expectedTyp: String?): String
 }

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/crypto/KBJWTBuilder.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/crypto/KBJWTBuilder.kt
@@ -37,12 +37,12 @@ object KBJWTBuilder {
         val iat = Clock.System.now().epochSeconds
         val payload = """{"nonce":"$nonce","aud":"$audience","iat":$iat,"sd_hash":"$sdHash"}"""
 
-        val headerEncoded = base64UrlEncode(header.encodeToByteArray())
-        val payloadEncoded = base64UrlEncode(payload.encodeToByteArray())
+        val headerEncoded = Base64Url.encode(header.encodeToByteArray())
+        val payloadEncoded = Base64Url.encode(payload.encodeToByteArray())
         val signingInput = "$headerEncoded.$payloadEncoded"
 
         val signatureBytes = keyManager.sign(keyAlias, signingInput.encodeToByteArray())
-        val signatureEncoded = base64UrlEncode(signatureBytes)
+        val signatureEncoded = Base64Url.encode(signatureBytes)
 
         return "$signingInput.$signatureEncoded"
     }
@@ -54,34 +54,6 @@ object KBJWTBuilder {
         // sha256Hash returns hex string, we need the raw bytes for base64url
         val hexHash = sha256Hash(sdJwtContent)
         val hashBytes = hexHash.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
-        return base64UrlEncode(hashBytes)
+        return Base64Url.encode(hashBytes)
     }
-
-    private fun base64UrlEncode(bytes: ByteArray): String {
-        val base64 = bytes.toBase64()
-        return base64
-            .replace('+', '-')
-            .replace('/', '_')
-            .trimEnd('=')
-    }
-}
-
-// Multiplatform base64 encoding (simple implementation)
-internal fun ByteArray.toBase64(): String {
-    val table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-    val sb = StringBuilder()
-    var i = 0
-    while (i < size) {
-        val b0 = this[i].toInt() and 0xFF
-        val b1 = if (i + 1 < size) this[i + 1].toInt() and 0xFF else 0
-        val b2 = if (i + 2 < size) this[i + 2].toInt() and 0xFF else 0
-        val remaining = size - i
-
-        sb.append(table[b0 shr 2])
-        sb.append(table[((b0 and 0x03) shl 4) or (b1 shr 4)])
-        if (remaining > 1) sb.append(table[((b1 and 0x0F) shl 2) or (b2 shr 6)]) else sb.append('=')
-        if (remaining > 2) sb.append(table[b2 and 0x3F]) else sb.append('=')
-        i += 3
-    }
-    return sb.toString()
 }

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/crypto/SDJWTParser.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/crypto/SDJWTParser.kt
@@ -30,6 +30,18 @@ object SDJWTParser {
     )
 
     /**
+     * A parsed SD-JWT presentation including the KB-JWT (used for verification).
+     */
+    data class ParsedPresentation(
+        val issuerJWT: String,
+        val disclosures: List<Disclosure>,
+        val claims: Map<String, JsonElement>,
+        val kbJwt: String?,
+        /** The SD-JWT content without KB-JWT (issuerJWT~disc1~disc2~...~) for sd_hash computation. */
+        val sdJwtForHash: String
+    )
+
+    /**
      * Parse an SD-JWT string into its components.
      * Extracts the issuer JWT and decodes all disclosures to extract claim names and values.
      */
@@ -60,6 +72,48 @@ object SDJWTParser {
     }
 
     /**
+     * Parse an SD-JWT presentation, extracting the KB-JWT if present.
+     * Used by the local verifier to access all components for verification.
+     */
+    fun parsePresentation(rawPresentation: String): ParsedPresentation {
+        val parts = rawPresentation.split("~")
+        require(parts.size >= 2) { "Invalid SD-JWT: expected at least issuer JWT and delimiter" }
+
+        val issuerJWT = parts[0]
+        val disclosures = mutableListOf<Disclosure>()
+        val claims = mutableMapOf<String, JsonElement>()
+        var kbJwt: String? = null
+        val sdJwtParts = mutableListOf(issuerJWT)
+
+        for (i in 1 until parts.size) {
+            val part = parts[i]
+            if (part.isEmpty()) continue
+
+            if (part.count { it == '.' } == 2) {
+                // This is a KB-JWT
+                kbJwt = part
+                continue
+            }
+
+            val disclosure = decodeDisclosure(part) ?: continue
+            disclosures.add(disclosure)
+            claims[disclosure.claimName] = disclosure.value
+            sdJwtParts.add(part)
+        }
+
+        // sdJwtForHash = issuerJWT~disc1~disc2~...~ (trailing ~, no KB-JWT)
+        val sdJwtForHash = sdJwtParts.joinToString("~") + "~"
+
+        return ParsedPresentation(
+            issuerJWT = issuerJWT,
+            disclosures = disclosures,
+            claims = claims,
+            kbJwt = kbJwt,
+            sdJwtForHash = sdJwtForHash
+        )
+    }
+
+    /**
      * Select only the disclosures needed for the requested claims.
      * Returns the SD-JWT string with only those disclosures included.
      */
@@ -75,7 +129,7 @@ object SDJWTParser {
 
     private fun decodeDisclosure(encoded: String): Disclosure? {
         return try {
-            val jsonStr = base64UrlDecode(encoded).decodeToString()
+            val jsonStr = Base64Url.decode(encoded).decodeToString()
             val arr = Json.parseToJsonElement(jsonStr).jsonArray
             if (arr.size != 3) return null
             Disclosure(
@@ -88,37 +142,4 @@ object SDJWTParser {
             null
         }
     }
-
-    private fun base64UrlDecode(input: String): ByteArray {
-        val base64 = input
-            .replace('-', '+')
-            .replace('_', '/')
-            .let { s ->
-                when (s.length % 4) {
-                    2 -> "$s=="
-                    3 -> "$s="
-                    else -> s
-                }
-            }
-        return base64Decode(base64)
-    }
-}
-
-// Simple multiplatform base64 decoder
-internal fun base64Decode(input: String): ByteArray {
-    val table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-    val result = mutableListOf<Byte>()
-    var i = 0
-    while (i < input.length) {
-        val c0 = table.indexOf(input[i])
-        val c1 = if (i + 1 < input.length) table.indexOf(input[i + 1]) else 0
-        val c2 = if (i + 2 < input.length && input[i + 2] != '=') table.indexOf(input[i + 2]) else -1
-        val c3 = if (i + 3 < input.length && input[i + 3] != '=') table.indexOf(input[i + 3]) else -1
-
-        result.add(((c0 shl 2) or (c1 shr 4)).toByte())
-        if (c2 >= 0) result.add((((c1 and 0x0F) shl 4) or (c2 shr 2)).toByte())
-        if (c3 >= 0) result.add((((c2 and 0x03) shl 6) or c3).toByte())
-        i += 4
-    }
-    return result.toByteArray()
 }

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/model/PackDefinition.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/model/PackDefinition.kt
@@ -1,0 +1,37 @@
+package id.cachet.wallet.domain.model
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Full pack definition matching the registry JSON schema.
+ * Cached locally for offline verification.
+ */
+@Serializable
+data class PackDefinition(
+    val id: String,
+    val version: String,
+    val name: String,
+    val purpose: String,
+    val jurisdictions: List<String>,
+    val badge: PackBadge,
+    val predicates: List<PackPredicate>
+)
+
+@Serializable
+data class PackBadge(
+    val label: String,
+    val ttl: String,
+    val jurisdiction: String
+)
+
+@Serializable
+data class PackPredicate(
+    val id: String,
+    val claim: String,
+    val operator: String,
+    val value: JsonPrimitive,
+    val issuersAccepted: List<String>,
+    val proofType: String,
+    val required: Boolean = true
+)

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/repository/DIDDocumentRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/repository/DIDDocumentRepository.kt
@@ -1,0 +1,13 @@
+package id.cachet.wallet.domain.repository
+
+data class CachedDIDDocument(
+    val did: String,
+    val documentJson: String,
+    val fetchedAt: Long
+)
+
+interface DIDDocumentRepository {
+    suspend fun getDocument(did: String): Result<CachedDIDDocument?>
+    suspend fun storeDocument(did: String, documentJson: String, fetchedAt: Long): Result<Unit>
+    suspend fun deleteExpired(cutoffEpochMs: Long): Result<Unit>
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/repository/PackDefinitionRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/repository/PackDefinitionRepository.kt
@@ -1,0 +1,12 @@
+package id.cachet.wallet.domain.repository
+
+import id.cachet.wallet.domain.model.PackDefinition
+
+interface PackDefinitionRepository {
+    suspend fun getPackById(packId: String): Result<PackDefinition?>
+    suspend fun getAllPacks(): Result<List<PackDefinition>>
+    suspend fun storePack(pack: PackDefinition): Result<Unit>
+    suspend fun storeAll(packs: List<PackDefinition>): Result<Unit>
+    suspend fun deleteAll(): Result<Unit>
+    suspend fun getLatestFetchedAt(): Result<Long?>
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/repository/SqlDelightDIDDocumentRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/repository/SqlDelightDIDDocumentRepository.kt
@@ -1,0 +1,45 @@
+package id.cachet.wallet.domain.repository
+
+import id.cachet.wallet.db.WalletDatabase
+
+class SqlDelightDIDDocumentRepository(
+    private val database: WalletDatabase
+) : DIDDocumentRepository {
+
+    override suspend fun getDocument(did: String): Result<CachedDIDDocument?> {
+        return try {
+            val row = database.walletDatabaseQueries.getDidDocument(did).executeAsOneOrNull()
+            Result.success(row?.let {
+                CachedDIDDocument(
+                    did = it.did,
+                    documentJson = it.document_json,
+                    fetchedAt = it.fetched_at
+                )
+            })
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun storeDocument(did: String, documentJson: String, fetchedAt: Long): Result<Unit> {
+        return try {
+            database.walletDatabaseQueries.upsertDidDocument(
+                did = did,
+                document_json = documentJson,
+                fetched_at = fetchedAt
+            )
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun deleteExpired(cutoffEpochMs: Long): Result<Unit> {
+        return try {
+            database.walletDatabaseQueries.deleteExpiredDidDocuments(cutoffEpochMs)
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/repository/SqlDelightPackDefinitionRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/repository/SqlDelightPackDefinitionRepository.kt
@@ -1,0 +1,85 @@
+package id.cachet.wallet.domain.repository
+
+import id.cachet.wallet.db.WalletDatabase
+import id.cachet.wallet.domain.model.PackDefinition
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class SqlDelightPackDefinitionRepository(
+    private val database: WalletDatabase
+) : PackDefinitionRepository {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun getPackById(packId: String): Result<PackDefinition?> {
+        return try {
+            val row = database.walletDatabaseQueries.getPackById(packId).executeAsOneOrNull()
+            Result.success(row?.let { json.decodeFromString<PackDefinition>(it.pack_json) })
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun getAllPacks(): Result<List<PackDefinition>> {
+        return try {
+            val rows = database.walletDatabaseQueries.getAllPacks().executeAsList()
+            Result.success(rows.map { json.decodeFromString<PackDefinition>(it.pack_json) })
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun storePack(pack: PackDefinition): Result<Unit> {
+        return try {
+            val now = kotlin.time.Clock.System.now().toEpochMilliseconds()
+            database.walletDatabaseQueries.upsertPack(
+                pack_id = pack.id,
+                version = pack.version,
+                name = pack.name,
+                pack_json = json.encodeToString(pack),
+                fetched_at = now
+            )
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun storeAll(packs: List<PackDefinition>): Result<Unit> {
+        return try {
+            val now = kotlin.time.Clock.System.now().toEpochMilliseconds()
+            database.walletDatabaseQueries.transaction {
+                for (pack in packs) {
+                    database.walletDatabaseQueries.upsertPack(
+                        pack_id = pack.id,
+                        version = pack.version,
+                        name = pack.name,
+                        pack_json = json.encodeToString(pack),
+                        fetched_at = now
+                    )
+                }
+            }
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun deleteAll(): Result<Unit> {
+        return try {
+            database.walletDatabaseQueries.deleteAllPacks()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun getLatestFetchedAt(): Result<Long?> {
+        return try {
+            val row = database.walletDatabaseQueries.getLatestPackFetchedAt().executeAsOneOrNull()
+            Result.success(row?.MAX)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/repository/SqlDelightStatusListRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/repository/SqlDelightStatusListRepository.kt
@@ -1,0 +1,45 @@
+package id.cachet.wallet.domain.repository
+
+import id.cachet.wallet.db.WalletDatabase
+
+class SqlDelightStatusListRepository(
+    private val database: WalletDatabase
+) : StatusListRepository {
+
+    override suspend fun getStatusList(url: String): Result<CachedStatusList?> {
+        return try {
+            val row = database.walletDatabaseQueries.getStatusList(url).executeAsOneOrNull()
+            Result.success(row?.let {
+                CachedStatusList(
+                    url = it.status_list_url,
+                    encodedList = it.encoded_list,
+                    fetchedAt = it.fetched_at
+                )
+            })
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun storeStatusList(url: String, encodedList: String, fetchedAt: Long): Result<Unit> {
+        return try {
+            database.walletDatabaseQueries.upsertStatusList(
+                status_list_url = url,
+                encoded_list = encodedList,
+                fetched_at = fetchedAt
+            )
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun deleteExpired(cutoffEpochMs: Long): Result<Unit> {
+        return try {
+            database.walletDatabaseQueries.deleteExpiredStatusLists(cutoffEpochMs)
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/repository/StatusListRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/repository/StatusListRepository.kt
@@ -1,0 +1,13 @@
+package id.cachet.wallet.domain.repository
+
+data class CachedStatusList(
+    val url: String,
+    val encodedList: String,
+    val fetchedAt: Long
+)
+
+interface StatusListRepository {
+    suspend fun getStatusList(url: String): Result<CachedStatusList?>
+    suspend fun storeStatusList(url: String, encodedList: String, fetchedAt: Long): Result<Unit>
+    suspend fun deleteExpired(cutoffEpochMs: Long): Result<Unit>
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/usecase/VerificationUseCase.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/usecase/VerificationUseCase.kt
@@ -1,6 +1,8 @@
 package id.cachet.wallet.domain.usecase
 
 import id.cachet.wallet.config.AppConfig
+import id.cachet.wallet.domain.cache.PackDefinitionCache
+import id.cachet.wallet.domain.crypto.Base64Url
 import id.cachet.wallet.domain.crypto.DIDResolver
 import id.cachet.wallet.domain.crypto.JWEEncryptor
 import id.cachet.wallet.domain.crypto.JWSVerifier
@@ -9,6 +11,8 @@ import id.cachet.wallet.domain.crypto.KeyManager
 import id.cachet.wallet.domain.crypto.SDJWTParser
 import id.cachet.wallet.domain.model.*
 import id.cachet.wallet.domain.repository.CredentialRepository
+import id.cachet.wallet.domain.verification.LocalVerificationResult
+import id.cachet.wallet.domain.verification.LocalVerifier
 import id.cachet.wallet.network.*
 import kotlinx.coroutines.delay
 import kotlinx.serialization.Serializable
@@ -31,7 +35,9 @@ class VerificationUseCase(
     private val relayClient: RelayClient,
     private val consentUseCase: ConsentUseCase,
     private val keyManager: KeyManager? = null,
-    private val didResolver: DIDResolver? = null
+    private val didResolver: DIDResolver? = null,
+    private val localVerifier: LocalVerifier? = null,
+    private val packDefinitionCache: PackDefinitionCache? = null
 ) {
 
     companion object {
@@ -79,17 +85,50 @@ class VerificationUseCase(
             qrPayload = qr,
             relayResponseUri = relaySession.responseUri,
             verificationSessionId = session.sessionId,
-            packId = packId
+            packId = packId,
+            sessionNonce = session.nonce,
+            verifierDid = session.verifierDid
         )
     }
 
     /**
      * Verifier polls the relay for the holder's response, then verifies it.
+     * Attempts local verification first; falls back to backend on failure.
      */
     suspend fun awaitAndVerifyRelayResponse(sessionInfo: VerifierSessionInfo): VerificationResult {
         val responseBytes = pollUntilResponse(sessionInfo.relayResponseUri)
         val presentation = responseBytes.decodeToString()
 
+        // Attempt local verification first
+        if (localVerifier != null && packDefinitionCache != null) {
+            val packDef = packDefinitionCache.getPackById(sessionInfo.packId)
+            if (packDef != null) {
+                val localResult = localVerifier.verify(
+                    sdJwtPresentation = presentation,
+                    packDefinition = packDef,
+                    sessionNonce = sessionInfo.sessionNonce,
+                    verifierDid = sessionInfo.verifierDid
+                )
+                when (localResult) {
+                    is LocalVerificationResult.Success -> return localResult.toVerificationResult(sessionInfo.packId)
+                    is LocalVerificationResult.Degraded -> return localResult.result.toVerificationResult(sessionInfo.packId)
+                    is LocalVerificationResult.VerificationFailed -> {
+                        // Crypto failures are definitive — don't fall back to backend
+                        return VerificationResult(
+                            packId = sessionInfo.packId,
+                            badge = "",
+                            freshness = "ok",
+                            predicateResults = emptyList(),
+                            summary = null,
+                            consentReceiptId = null,
+                            holderBound = false
+                        )
+                    }
+                }
+            }
+        }
+
+        // Backend fallback (existing path)
         val response = verifierClient.verifySDJWTPresentation(
             policyId = sessionInfo.packId,
             sdJwtCredentials = listOf(presentation),
@@ -106,6 +145,16 @@ class VerificationUseCase(
             holderBound = true
         )
     }
+
+    private fun LocalVerificationResult.Success.toVerificationResult(packId: String) = VerificationResult(
+        packId = packId,
+        badge = badge,
+        freshness = freshness,
+        predicateResults = predicateResults,
+        summary = summary,
+        consentReceiptId = null,
+        holderBound = holderBound
+    )
 
     // ── Relay flow: holder side ──
 
@@ -131,14 +180,14 @@ class VerificationUseCase(
     private suspend fun verifyAndParseRequestObject(jwsCompact: String): VerifiedRequest {
         // Extract client_id from unverified payload to know which DID to resolve
         val payloadPart = jwsCompact.split(".")[1]
-        val payloadJson = decodeBase64Url(payloadPart).decodeToString()
+        val payloadJson = Base64Url.decode(payloadPart).decodeToString()
         val unverified = Json.parseToJsonElement(payloadJson).jsonObject
         val clientId = unverified["client_id"]?.jsonPrimitive?.content
             ?: throw IllegalStateException("Missing client_id in request object")
 
         // Extract kid from JWS header
         val headerPart = jwsCompact.split(".")[0]
-        val headerJson = decodeBase64Url(headerPart).decodeToString()
+        val headerJson = Base64Url.decode(headerPart).decodeToString()
         val header = Json.parseToJsonElement(headerJson).jsonObject
         val kid = header["kid"]?.jsonPrimitive?.content
 
@@ -169,30 +218,6 @@ class VerificationUseCase(
             verifierName = clientMetadata?.get("client_name")?.jsonPrimitive?.content,
             isVerified = true
         )
-    }
-
-    private fun decodeBase64Url(s: String): ByteArray {
-        val padded = s + "=".repeat((4 - s.length % 4) % 4)
-        val standard = padded.replace('-', '+').replace('_', '/')
-        // Use the same base64 decode as KBJWTBuilder (custom multiplatform impl)
-        return decodeBase64(standard)
-    }
-
-    private fun decodeBase64(s: String): ByteArray {
-        val table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-        val result = mutableListOf<Byte>()
-        var i = 0
-        while (i < s.length) {
-            val a = if (s[i] != '=') table.indexOf(s[i]) else 0
-            val b = if (i + 1 < s.length && s[i + 1] != '=') table.indexOf(s[i + 1]) else 0
-            val c = if (i + 2 < s.length && s[i + 2] != '=') table.indexOf(s[i + 2]) else 0
-            val d = if (i + 3 < s.length && s[i + 3] != '=') table.indexOf(s[i + 3]) else 0
-            result.add(((a shl 2) or (b shr 4)).toByte())
-            if (i + 2 < s.length && s[i + 2] != '=') result.add((((b and 0xF) shl 4) or (c shr 2)).toByte())
-            if (i + 3 < s.length && s[i + 3] != '=') result.add((((c and 0x3) shl 6) or d).toByte())
-            i += 4
-        }
-        return result.toByteArray()
     }
 
     /**
@@ -405,7 +430,9 @@ data class VerifierSessionInfo(
     val qrPayload: String,
     val relayResponseUri: String,
     val verificationSessionId: String,
-    val packId: String
+    val packId: String,
+    val sessionNonce: String = "",
+    val verifierDid: String = ""
 )
 
 /** Holder-side result of fetching and verifying the Request Object from the relay. */

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/verification/FreshnessChecker.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/verification/FreshnessChecker.kt
@@ -1,0 +1,33 @@
+package id.cachet.wallet.domain.verification
+
+import kotlin.time.Clock
+
+/**
+ * Checks credential freshness based on expiration and staleness thresholds.
+ *
+ * Port of Go `services/verifier/internal/eval/freshness.go`.
+ */
+object FreshnessChecker {
+
+    private const val STALE_THRESHOLD_SECONDS = 90L * 24 * 60 * 60 // 90 days
+
+    /**
+     * Check freshness of a credential given its iat and exp (epoch seconds).
+     * Returns "ok", "stale", or "expired".
+     */
+    fun check(issuedAtSeconds: Long?, expirationSeconds: Long?): String {
+        val nowSeconds = Clock.System.now().epochSeconds
+
+        // Check expiration
+        if (expirationSeconds != null && nowSeconds > expirationSeconds) {
+            return "expired"
+        }
+
+        // Check staleness (>90 days since issuance)
+        if (issuedAtSeconds != null && (nowSeconds - issuedAtSeconds) > STALE_THRESHOLD_SECONDS) {
+            return "stale"
+        }
+
+        return "ok"
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/verification/IssuerMatcher.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/verification/IssuerMatcher.kt
@@ -1,0 +1,21 @@
+package id.cachet.wallet.domain.verification
+
+/**
+ * Matches issuer DIDs against accepted patterns.
+ * Supports exact match and trailing wildcard (e.g., "did:veriff:*" matches "did:veriff:production").
+ *
+ * Port of Go `services/verifier/internal/eval/issuer.go`.
+ */
+object IssuerMatcher {
+
+    fun matches(issuer: String, patterns: List<String>): Boolean {
+        for (pattern in patterns) {
+            if (pattern == issuer) return true
+            if (pattern.endsWith("*")) {
+                val prefix = pattern.removeSuffix("*")
+                if (issuer.startsWith(prefix)) return true
+            }
+        }
+        return false
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/verification/KBJWTVerifier.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/verification/KBJWTVerifier.kt
@@ -1,0 +1,88 @@
+package id.cachet.wallet.domain.verification
+
+import id.cachet.wallet.domain.crypto.Base64Url
+import id.cachet.wallet.domain.crypto.JWSVerifier
+import kotlin.time.Clock
+import kotlinx.serialization.json.*
+
+/**
+ * Verifies Key Binding JWTs (KB-JWT) for holder binding.
+ *
+ * Checks: signature against cnf.jwk, typ == "kb+jwt", sd_hash integrity, iat freshness (5 min).
+ *
+ * Port of Go `services/verifier/internal/eval/kbjwt.go`.
+ */
+class KBJWTVerifier(
+    private val jwsVerifier: JWSVerifier = JWSVerifier(),
+    private val clock: Clock = Clock.System
+) {
+    companion object {
+        private const val MAX_AGE_SECONDS = 5 * 60L // 5 minutes
+    }
+
+    data class KBJWTResult(
+        val nonce: String,
+        val aud: String,
+        val sdHash: String,
+        val issuedAt: Long
+    )
+
+    /**
+     * Verify a KB-JWT against the holder's cnf claim and expected sd_hash.
+     *
+     * @param kbJwtString The KB-JWT compact serialization
+     * @param cnf The cnf claim from the issuer JWT (contains holder's public key JWK)
+     * @param expectedSDHash The expected sd_hash (base64url(sha256(issuerJWT~disc1~...~)))
+     * @return Verified KB-JWT claims
+     * @throws IllegalStateException on verification failure
+     */
+    fun verify(kbJwtString: String, cnf: JsonObject, expectedSDHash: String): KBJWTResult {
+        require(kbJwtString.isNotEmpty()) { "KB-JWT is empty" }
+
+        // Extract holder's public key from cnf.jwk
+        val holderKeyJWK = extractCNFKeyJWK(cnf)
+
+        // Verify signature using JWSVerifier
+        val payloadJson = jwsVerifier.verifyJWS(kbJwtString, holderKeyJWK, "kb+jwt")
+        val claims = Json.parseToJsonElement(payloadJson).jsonObject
+
+        // Verify sd_hash matches
+        val sdHash = claims["sd_hash"]?.jsonPrimitive?.content
+            ?: throw IllegalStateException("Missing sd_hash in KB-JWT")
+        if (sdHash != expectedSDHash) {
+            throw IllegalStateException("sd_hash mismatch: KB-JWT binds to different disclosure set")
+        }
+
+        // Check iat freshness (max 5 minutes old)
+        val iat = claims["iat"]?.jsonPrimitive?.longOrNull
+            ?: throw IllegalStateException("Missing or invalid iat in KB-JWT")
+        val now = clock.now().epochSeconds
+        if ((now - iat) > MAX_AGE_SECONDS) {
+            throw IllegalStateException("KB-JWT expired: issued ${now - iat}s ago (max ${MAX_AGE_SECONDS}s)")
+        }
+
+        return KBJWTResult(
+            nonce = claims["nonce"]?.jsonPrimitive?.content ?: "",
+            aud = claims["aud"]?.jsonPrimitive?.content ?: "",
+            sdHash = sdHash,
+            issuedAt = iat
+        )
+    }
+
+    /**
+     * Extract the holder's public key JWK JSON string from the cnf claim.
+     * Expected: cnf: { jwk: { kty: "EC", crv: "P-256", x: "...", y: "..." } }
+     */
+    private fun extractCNFKeyJWK(cnf: JsonObject): String {
+        val jwk = cnf["jwk"]?.jsonObject
+            ?: throw IllegalStateException("cnf.jwk not found")
+
+        val kty = jwk["kty"]?.jsonPrimitive?.content
+        if (kty != "EC") throw IllegalStateException("Unsupported key type: $kty (expected EC)")
+
+        val crv = jwk["crv"]?.jsonPrimitive?.content
+        if (crv != "P-256") throw IllegalStateException("Unsupported curve: $crv (expected P-256)")
+
+        return jwk.toString()
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/verification/LocalVerificationResult.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/verification/LocalVerificationResult.kt
@@ -1,0 +1,38 @@
+package id.cachet.wallet.domain.verification
+
+import id.cachet.wallet.network.PredicateResultDTO
+import id.cachet.wallet.network.VerificationSummaryDTO
+
+sealed class LocalVerificationResult {
+
+    data class Success(
+        val badge: String,
+        val freshness: String,
+        val predicateResults: List<PredicateResultDTO>,
+        val summary: VerificationSummaryDTO,
+        val holderBound: Boolean,
+        val revocationChecked: Boolean
+    ) : LocalVerificationResult()
+
+    data class VerificationFailed(
+        val reason: String,
+        val step: VerificationStep
+    ) : LocalVerificationResult()
+
+    data class Degraded(
+        val result: Success,
+        val warnings: List<String>
+    ) : LocalVerificationResult()
+}
+
+enum class VerificationStep {
+    PARSE,
+    ISSUER_SIGNATURE,
+    SD_ALG,
+    DISCLOSURE_HASH,
+    KB_JWT,
+    NONCE,
+    AUDIENCE,
+    REVOKED,
+    EXPIRED
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/verification/LocalVerifier.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/verification/LocalVerifier.kt
@@ -1,0 +1,215 @@
+package id.cachet.wallet.domain.verification
+
+import id.cachet.wallet.domain.cache.CachedDIDResolver
+import id.cachet.wallet.domain.cache.StatusListCache
+import id.cachet.wallet.domain.crypto.Base64Url
+import id.cachet.wallet.domain.crypto.DIDResolver
+import id.cachet.wallet.domain.crypto.JWSVerifier
+import id.cachet.wallet.domain.crypto.KBJWTBuilder
+import id.cachet.wallet.domain.crypto.SDJWTParser
+import id.cachet.wallet.domain.model.PackDefinition
+import id.cachet.wallet.domain.model.sha256Hash
+import kotlinx.serialization.json.*
+
+/**
+ * Local SD-JWT verification pipeline, run entirely on the verifier's device.
+ *
+ * Port of Go `services/verifier/server.go` lines 172-311 and
+ * `services/verifier/internal/eval/sdjwt_parser.go` VerifySDJWT.
+ *
+ * Steps:
+ * 1. Parse SD-JWT → issuerJWT + disclosures + KB-JWT
+ * 2. Decode issuer JWT payload → extract iss, _sd_alg, _sd, cnf, status, exp, iat
+ * 3. Resolve issuer DID → public key (via CachedDIDResolver)
+ * 4. Verify issuer JWS signature
+ * 5. Verify _sd_alg == "sha-256"
+ * 6. Compute + verify disclosure hashes against _sd array
+ * 7. Merge verified claims
+ * 8. If KB-JWT: verify via KBJWTVerifier
+ * 9. Check freshness
+ * 10. Check revocation (best-effort)
+ * 11. Evaluate predicates
+ */
+class LocalVerifier(
+    private val cachedDIDResolver: CachedDIDResolver,
+    private val jwsVerifier: JWSVerifier = JWSVerifier(),
+    private val kbJwtVerifier: KBJWTVerifier = KBJWTVerifier(jwsVerifier),
+    private val statusListCache: StatusListCache? = null
+) {
+
+    suspend fun verify(
+        sdJwtPresentation: String,
+        packDefinition: PackDefinition,
+        sessionNonce: String? = null,
+        verifierDid: String? = null
+    ): LocalVerificationResult {
+        val warnings = mutableListOf<String>()
+
+        // Step 1: Parse SD-JWT presentation
+        val parsed = try {
+            SDJWTParser.parsePresentation(sdJwtPresentation)
+        } catch (e: Exception) {
+            return LocalVerificationResult.VerificationFailed("Parse error: ${e.message}", VerificationStep.PARSE)
+        }
+
+        // Step 2: Decode issuer JWT payload (without verification)
+        val issuerPayload = try {
+            val parts = parsed.issuerJWT.split(".")
+            if (parts.size != 3) throw IllegalArgumentException("Invalid JWT structure")
+            val payloadJson = Base64Url.decode(parts[1]).decodeToString()
+            Json.parseToJsonElement(payloadJson).jsonObject
+        } catch (e: Exception) {
+            return LocalVerificationResult.VerificationFailed("Failed to decode issuer JWT: ${e.message}", VerificationStep.PARSE)
+        }
+
+        val issuer = issuerPayload["iss"]?.jsonPrimitive?.content
+            ?: return LocalVerificationResult.VerificationFailed("Missing iss claim", VerificationStep.PARSE)
+
+        // Step 3: Resolve issuer DID to public key
+        val publicKeyJWK = try {
+            cachedDIDResolver.resolvePublicKeyJWK(issuer)
+        } catch (e: Exception) {
+            return LocalVerificationResult.VerificationFailed("Failed to resolve issuer DID: ${e.message}", VerificationStep.ISSUER_SIGNATURE)
+        }
+
+        // Step 4: Verify issuer JWS signature
+        try {
+            jwsVerifier.verifyJWS(parsed.issuerJWT, publicKeyJWK, null)
+        } catch (e: Exception) {
+            return LocalVerificationResult.VerificationFailed("Issuer signature invalid: ${e.message}", VerificationStep.ISSUER_SIGNATURE)
+        }
+
+        // Step 5: Verify _sd_alg == "sha-256"
+        val sdAlg = issuerPayload["_sd_alg"]?.jsonPrimitive?.content
+        if (sdAlg != "sha-256") {
+            return LocalVerificationResult.VerificationFailed("Unsupported _sd_alg: $sdAlg (only sha-256 accepted)", VerificationStep.SD_ALG)
+        }
+
+        // Step 6: Compute + verify disclosure hashes against _sd array
+        val sdArray = issuerPayload["_sd"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull }?.toSet()
+            ?: emptySet()
+
+        val mergedClaims = mutableMapOf<String, JsonElement>()
+        for (disc in parsed.disclosures) {
+            val disclosureHash = computeDisclosureHash(disc.encoded)
+            if (disclosureHash !in sdArray) {
+                return LocalVerificationResult.VerificationFailed(
+                    "Disclosure hash for claim '${disc.claimName}' not found in _sd array",
+                    VerificationStep.DISCLOSURE_HASH
+                )
+            }
+            mergedClaims[disc.claimName] = disc.value
+        }
+
+        // Step 7: Build verified claims
+        val iat = issuerPayload["iat"]?.jsonPrimitive?.longOrNull
+        val exp = issuerPayload["exp"]?.jsonPrimitive?.longOrNull
+        val status = issuerPayload["status"]?.jsonObject
+        var holderBound = false
+        var kbNonce: String? = null
+        var kbAud: String? = null
+
+        // Step 8: Verify KB-JWT if present
+        if (parsed.kbJwt != null) {
+            val cnf = issuerPayload["cnf"]?.jsonObject
+            if (cnf == null) {
+                return LocalVerificationResult.VerificationFailed(
+                    "KB-JWT present but credential has no cnf claim",
+                    VerificationStep.KB_JWT
+                )
+            }
+
+            val expectedSDHash = KBJWTBuilder.computeSDHash(parsed.sdJwtForHash)
+            val kbResult = try {
+                kbJwtVerifier.verify(parsed.kbJwt, cnf, expectedSDHash)
+            } catch (e: Exception) {
+                return LocalVerificationResult.VerificationFailed("KB-JWT verification failed: ${e.message}", VerificationStep.KB_JWT)
+            }
+
+            // Verify nonce if session context provided
+            if (sessionNonce != null && kbResult.nonce != sessionNonce) {
+                return LocalVerificationResult.VerificationFailed(
+                    "Nonce mismatch: expected $sessionNonce, got ${kbResult.nonce}",
+                    VerificationStep.NONCE
+                )
+            }
+
+            // Verify audience if verifier DID provided
+            if (verifierDid != null && kbResult.aud != verifierDid) {
+                return LocalVerificationResult.VerificationFailed(
+                    "Audience mismatch: expected $verifierDid, got ${kbResult.aud}",
+                    VerificationStep.AUDIENCE
+                )
+            }
+
+            holderBound = true
+            kbNonce = kbResult.nonce
+            kbAud = kbResult.aud
+        }
+
+        val verifiedClaims = VerifiedClaims(
+            issuer = issuer,
+            claims = mergedClaims,
+            issuedAt = iat,
+            expiration = exp,
+            status = status,
+            holderBound = holderBound,
+            kbJwtNonce = kbNonce,
+            kbJwtAud = kbAud
+        )
+
+        // Step 9: Check freshness
+        val freshness = FreshnessChecker.check(iat, exp)
+        if (freshness == "expired") {
+            return LocalVerificationResult.VerificationFailed("Credential has expired", VerificationStep.EXPIRED)
+        }
+
+        // Step 10: Check revocation (best-effort)
+        var revocationChecked = false
+        if (status != null && statusListCache != null) {
+            val statusListUrl = status["statusListCredential"]?.jsonPrimitive?.content
+            val statusListIndex = status["statusListIndex"]?.jsonPrimitive?.content?.toIntOrNull()
+            if (statusListUrl != null && statusListIndex != null) {
+                try {
+                    val isRevoked = statusListCache.isRevoked(statusListUrl, statusListIndex)
+                    if (isRevoked == true) {
+                        return LocalVerificationResult.VerificationFailed("Credential has been revoked", VerificationStep.REVOKED)
+                    }
+                    revocationChecked = (isRevoked != null)
+                } catch (e: Exception) {
+                    warnings.add("Revocation check failed: ${e.message}")
+                }
+            }
+        } else if (status != null) {
+            warnings.add("Status list cache unavailable, revocation check skipped")
+        }
+
+        // Step 11: Evaluate predicates
+        val evaluation = PredicateEvaluator.evaluate(packDefinition, listOf(verifiedClaims))
+
+        val badge = if (evaluation.summary.cachetGranted) packDefinition.badge.label else ""
+        val success = LocalVerificationResult.Success(
+            badge = badge,
+            freshness = freshness,
+            predicateResults = evaluation.predicateResults,
+            summary = evaluation.summary,
+            holderBound = holderBound,
+            revocationChecked = revocationChecked
+        )
+
+        return if (warnings.isNotEmpty()) {
+            LocalVerificationResult.Degraded(result = success, warnings = warnings)
+        } else {
+            success
+        }
+    }
+
+    /**
+     * Compute disclosure hash: base64url(sha256(encoded_disclosure))
+     */
+    private fun computeDisclosureHash(encodedDisclosure: String): String {
+        val hexHash = sha256Hash(encodedDisclosure)
+        val hashBytes = hexHash.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+        return Base64Url.encode(hashBytes)
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/verification/PredicateEvaluator.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/verification/PredicateEvaluator.kt
@@ -1,0 +1,110 @@
+package id.cachet.wallet.domain.verification
+
+import id.cachet.wallet.domain.model.PackDefinition
+import id.cachet.wallet.domain.model.PackPredicate
+import id.cachet.wallet.network.PredicateResultDTO
+import id.cachet.wallet.network.VerificationSummaryDTO
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.doubleOrNull
+
+/**
+ * Evaluates pack predicates against cryptographically verified claims.
+ *
+ * Port of Go `services/verifier/internal/eval/evaluator.go` + `sdjwt.go`.
+ */
+object PredicateEvaluator {
+
+    data class EvaluationResult(
+        val predicateResults: List<PredicateResultDTO>,
+        val summary: VerificationSummaryDTO
+    )
+
+    fun evaluate(pack: PackDefinition, verifiedClaims: List<VerifiedClaims>): EvaluationResult {
+        val results = mutableListOf<PredicateResultDTO>()
+        var requiredTotal = 0
+        var requiredSatisfied = 0
+        var optionalTotal = 0
+        var optionalSatisfied = 0
+
+        for (pred in pack.predicates) {
+            val result = evaluatePredicate(pred, verifiedClaims)
+            results.add(result)
+
+            if (pred.required) {
+                requiredTotal++
+                if (result.status == "satisfied") requiredSatisfied++
+            } else {
+                optionalTotal++
+                if (result.status == "satisfied") optionalSatisfied++
+            }
+        }
+
+        return EvaluationResult(
+            predicateResults = results,
+            summary = VerificationSummaryDTO(
+                requiredSatisfied = requiredSatisfied,
+                requiredTotal = requiredTotal,
+                optionalSatisfied = optionalSatisfied,
+                optionalTotal = optionalTotal,
+                cachetGranted = requiredSatisfied == requiredTotal
+            )
+        )
+    }
+
+    private fun evaluatePredicate(pred: PackPredicate, verifiedClaims: List<VerifiedClaims>): PredicateResultDTO {
+        for (vc in verifiedClaims) {
+            if (!IssuerMatcher.matches(vc.issuer, pred.issuersAccepted)) continue
+
+            val actual = vc.claims[pred.claim] ?: continue
+
+            val (satisfied, reason) = evaluateOperator(pred.operator, actual, pred.value)
+            return if (satisfied) {
+                PredicateResultDTO(predicateId = pred.id, status = "satisfied")
+            } else {
+                PredicateResultDTO(predicateId = pred.id, status = "failed", reason = reason)
+            }
+        }
+        return PredicateResultDTO(
+            predicateId = pred.id,
+            status = "no_credential",
+            reason = "no credential from an accepted issuer"
+        )
+    }
+
+    private fun evaluateOperator(op: String, actual: JsonElement, expected: JsonPrimitive): Pair<Boolean, String?> {
+        return when (op) {
+            "boolean" -> {
+                val actualBool = (actual as? JsonPrimitive)?.booleanOrNull
+                    ?: return false to "expected boolean, got $actual"
+                val expectedBool = expected.booleanOrNull
+                    ?: return false to "expected boolean value, got $expected"
+                if (actualBool == expectedBool) true to null
+                else false to "expected $expectedBool, got $actualBool"
+            }
+            ">=" -> compareNumbers(actual, expected) { a, e -> a >= e }
+            ">" -> compareNumbers(actual, expected) { a, e -> a > e }
+            "<" -> compareNumbers(actual, expected) { a, e -> a < e }
+            "<=" -> compareNumbers(actual, expected) { a, e -> a <= e }
+            "==" -> {
+                if (actual.toString() == expected.toString()) true to null
+                else false to "expected == $expected, got $actual"
+            }
+            else -> false to "unsupported operator: $op"
+        }
+    }
+
+    private fun compareNumbers(
+        actual: JsonElement,
+        expected: JsonPrimitive,
+        compare: (Double, Double) -> Boolean
+    ): Pair<Boolean, String?> {
+        val actualNum = (actual as? JsonPrimitive)?.doubleOrNull
+            ?: return false to "expected number, got $actual"
+        val expectedNum = expected.doubleOrNull
+            ?: return false to "expected number value, got $expected"
+        return if (compare(actualNum, expectedNum)) true to null
+        else false to "expected $expected, got $actualNum"
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/verification/VerifiedClaims.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/verification/VerifiedClaims.kt
@@ -1,0 +1,19 @@
+package id.cachet.wallet.domain.verification
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Result of cryptographically verifying an SD-JWT presentation.
+ * Contains only claims whose disclosure hashes and issuer signatures have been checked.
+ */
+data class VerifiedClaims(
+    val issuer: String,
+    val claims: Map<String, JsonElement>,
+    val issuedAt: Long? = null,       // epoch seconds
+    val expiration: Long? = null,     // epoch seconds
+    val status: JsonObject? = null,   // credentialStatus for revocation checking
+    val holderBound: Boolean = false,
+    val kbJwtNonce: String? = null,
+    val kbJwtAud: String? = null
+)

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/shared/di/SharedModule.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/shared/di/SharedModule.kt
@@ -5,7 +5,19 @@ import id.cachet.wallet.domain.repository.ConsentReceiptRepository
 import id.cachet.wallet.domain.repository.SqlDelightConsentReceiptRepository
 import id.cachet.wallet.domain.repository.TransparencyLogRepository
 import id.cachet.wallet.domain.repository.HttpTransparencyLogRepository
+import id.cachet.wallet.domain.repository.PackDefinitionRepository
+import id.cachet.wallet.domain.repository.SqlDelightPackDefinitionRepository
+import id.cachet.wallet.domain.repository.DIDDocumentRepository
+import id.cachet.wallet.domain.repository.SqlDelightDIDDocumentRepository
+import id.cachet.wallet.domain.repository.StatusListRepository
+import id.cachet.wallet.domain.repository.SqlDelightStatusListRepository
 import id.cachet.wallet.domain.crypto.DIDResolver
+import id.cachet.wallet.domain.cache.BundledPackLoader
+import id.cachet.wallet.domain.cache.CachedDIDResolver
+import id.cachet.wallet.domain.cache.PackDefinitionCache
+import id.cachet.wallet.domain.cache.StatusListCache
+import id.cachet.wallet.domain.verification.KBJWTVerifier
+import id.cachet.wallet.domain.verification.LocalVerifier
 import id.cachet.wallet.domain.usecase.IssuanceUseCase
 import id.cachet.wallet.domain.usecase.ConsentUseCase
 import id.cachet.wallet.domain.usecase.VerificationUseCase
@@ -81,11 +93,36 @@ val sharedModule = module {
             httpClient = get()
         )
     }
+    single<PackDefinitionRepository> {
+        SqlDelightPackDefinitionRepository(database = get<WalletDatabase>())
+    }
+    single<DIDDocumentRepository> {
+        SqlDelightDIDDocumentRepository(database = get<WalletDatabase>())
+    }
+    single<StatusListRepository> {
+        SqlDelightStatusListRepository(database = get<WalletDatabase>())
+    }
 
     // KeyManager is provided by the platform-specific module (e.g. androidModule)
 
-    // DID resolution for verifier identity verification
+    // DID resolution — cached decorator with 24h TTL over HTTP resolver
     single { DIDResolver(httpClient = get()) }
+    single { CachedDIDResolver(delegate = get(), repository = get()) }
+
+    // Offline caches
+    // BundledPackLoader is provided by the platform-specific module
+    single {
+        PackDefinitionCache(
+            repository = get(),
+            loadBundled = { get<BundledPackLoader>().loadBundledPacks() }
+        )
+    }
+    single {
+        StatusListCache(
+            repository = get(),
+            httpClient = get()
+        )
+    }
 
     // Use cases
     single {
@@ -104,6 +141,14 @@ val sharedModule = module {
         )
     }
 
+    // Local SD-JWT verifier for offline verification
+    single {
+        LocalVerifier(
+            cachedDIDResolver = get(),
+            statusListCache = get()
+        )
+    }
+
     single {
         VerificationUseCase(
             credentialRepository = get(),
@@ -111,7 +156,9 @@ val sharedModule = module {
             relayClient = get(),
             consentUseCase = get(),
             keyManager = get(),
-            didResolver = get()
+            didResolver = get(),
+            localVerifier = get(),
+            packDefinitionCache = get()
         )
     }
 }

--- a/mobile/shared/src/commonMain/sqldelight/id/cachet/wallet/db/WalletDatabase.sq
+++ b/mobile/shared/src/commonMain/sqldelight/id/cachet/wallet/db/WalletDatabase.sq
@@ -72,3 +72,76 @@ SELECT * FROM consent_receipts WHERE credential_id = ? ORDER BY timestamp DESC;
 
 deleteReceipt:
 DELETE FROM consent_receipts WHERE id = ?;
+
+-- Offline cache: pack definitions
+CREATE TABLE cached_packs (
+    pack_id TEXT NOT NULL,
+    version TEXT NOT NULL,
+    name TEXT NOT NULL,
+    pack_json TEXT NOT NULL,
+    fetched_at INTEGER NOT NULL,
+    PRIMARY KEY (pack_id, version)
+);
+
+CREATE INDEX idx_cached_packs_fetched ON cached_packs(fetched_at);
+
+getPackById:
+SELECT * FROM cached_packs WHERE pack_id = ?
+ORDER BY fetched_at DESC LIMIT 1;
+
+getAllPacks:
+SELECT * FROM cached_packs
+ORDER BY name;
+
+upsertPack:
+INSERT OR REPLACE INTO cached_packs (pack_id, version, name, pack_json, fetched_at)
+VALUES (?, ?, ?, ?, ?);
+
+deletePackById:
+DELETE FROM cached_packs WHERE pack_id = ?;
+
+deleteAllPacks:
+DELETE FROM cached_packs;
+
+getLatestPackFetchedAt:
+SELECT MAX(fetched_at) FROM cached_packs;
+
+-- Offline cache: DID documents
+CREATE TABLE cached_did_documents (
+    did TEXT PRIMARY KEY NOT NULL,
+    document_json TEXT NOT NULL,
+    fetched_at INTEGER NOT NULL
+);
+
+getDidDocument:
+SELECT * FROM cached_did_documents WHERE did = ?;
+
+upsertDidDocument:
+INSERT OR REPLACE INTO cached_did_documents (did, document_json, fetched_at)
+VALUES (?, ?, ?);
+
+deleteDidDocument:
+DELETE FROM cached_did_documents WHERE did = ?;
+
+deleteExpiredDidDocuments:
+DELETE FROM cached_did_documents WHERE fetched_at < ?;
+
+-- Offline cache: StatusList2021 bitstrings
+CREATE TABLE cached_status_lists (
+    status_list_url TEXT PRIMARY KEY NOT NULL,
+    encoded_list TEXT NOT NULL,
+    fetched_at INTEGER NOT NULL
+);
+
+getStatusList:
+SELECT * FROM cached_status_lists WHERE status_list_url = ?;
+
+upsertStatusList:
+INSERT OR REPLACE INTO cached_status_lists (status_list_url, encoded_list, fetched_at)
+VALUES (?, ?, ?);
+
+deleteStatusList:
+DELETE FROM cached_status_lists WHERE status_list_url = ?;
+
+deleteExpiredStatusLists:
+DELETE FROM cached_status_lists WHERE fetched_at < ?;

--- a/mobile/shared/src/commonMain/sqldelight/migrations/3.sqm
+++ b/mobile/shared/src/commonMain/sqldelight/migrations/3.sqm
@@ -1,0 +1,24 @@
+-- Migration from version 3 to 4: add offline cache tables
+
+CREATE TABLE cached_packs (
+    pack_id TEXT NOT NULL,
+    version TEXT NOT NULL,
+    name TEXT NOT NULL,
+    pack_json TEXT NOT NULL,
+    fetched_at INTEGER NOT NULL,
+    PRIMARY KEY (pack_id, version)
+);
+
+CREATE INDEX idx_cached_packs_fetched ON cached_packs(fetched_at);
+
+CREATE TABLE cached_did_documents (
+    did TEXT PRIMARY KEY NOT NULL,
+    document_json TEXT NOT NULL,
+    fetched_at INTEGER NOT NULL
+);
+
+CREATE TABLE cached_status_lists (
+    status_list_url TEXT PRIMARY KEY NOT NULL,
+    encoded_list TEXT NOT NULL,
+    fetched_at INTEGER NOT NULL
+);

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/cache/PackDefinitionCacheTest.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/cache/PackDefinitionCacheTest.kt
@@ -1,0 +1,123 @@
+package id.cachet.wallet.domain.cache
+
+import id.cachet.wallet.domain.model.PackBadge
+import id.cachet.wallet.domain.model.PackDefinition
+import id.cachet.wallet.domain.model.PackPredicate
+import id.cachet.wallet.testfixtures.FakePackDefinitionRepository
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
+
+class PackDefinitionCacheTest {
+
+    private val testPack = PackDefinition(
+        id = "pack.identity.basic",
+        version = "0.1.0",
+        name = "Identity Verification",
+        purpose = "Verify core identity attributes",
+        jurisdictions = listOf("GLOBAL"),
+        badge = PackBadge(label = "Identity Verified", ttl = "P180D", jurisdiction = "GLOBAL"),
+        predicates = listOf(
+            PackPredicate(
+                id = "age.ge.18",
+                claim = "age",
+                operator = ">=",
+                value = JsonPrimitive(18),
+                issuersAccepted = listOf("did:veriff:*"),
+                proofType = "sd-jwt"
+            )
+        )
+    )
+
+    private val loadBundled = { listOf(testPack) }
+
+    @Test
+    fun getAllPacks_emptyCache_seedsFromBundled() = runTest {
+        val repo = FakePackDefinitionRepository()
+        val cache = PackDefinitionCache(repo, loadBundled)
+
+        val packs = cache.getAllPacks()
+
+        assertEquals(1, packs.size)
+        assertEquals("pack.identity.basic", packs[0].id)
+    }
+
+    @Test
+    fun getAllPacks_freshCache_returnsCached() = runTest {
+        val repo = FakePackDefinitionRepository()
+        repo.storeAll(listOf(testPack))
+        val cache = PackDefinitionCache(repo, loadBundled)
+
+        val packs = cache.getAllPacks()
+
+        assertEquals(1, packs.size)
+        assertEquals("pack.identity.basic", packs[0].id)
+    }
+
+    @Test
+    fun getPackById_existsInCache_returnsCached() = runTest {
+        val repo = FakePackDefinitionRepository()
+        repo.storePack(testPack)
+        val cache = PackDefinitionCache(repo, loadBundled)
+
+        val pack = cache.getPackById("pack.identity.basic")
+
+        assertNotNull(pack)
+        assertEquals("Identity Verification", pack.name)
+    }
+
+    @Test
+    fun getPackById_notInCache_seedsAndReturns() = runTest {
+        val repo = FakePackDefinitionRepository()
+        val cache = PackDefinitionCache(repo, loadBundled)
+
+        val pack = cache.getPackById("pack.identity.basic")
+
+        assertNotNull(pack)
+        assertEquals("Identity Verification", pack.name)
+    }
+
+    @Test
+    fun getPackById_unknownPack_returnsNull() = runTest {
+        val repo = FakePackDefinitionRepository()
+        val cache = PackDefinitionCache(repo, loadBundled)
+
+        val pack = cache.getPackById("pack.unknown")
+
+        assertNull(pack)
+    }
+
+    @Test
+    fun getAllPacks_staleCache_refreshesFromBundled() = runTest {
+        val repo = FakePackDefinitionRepository()
+        repo.storeAll(listOf(testPack))
+
+        val staleClock = object : Clock {
+            override fun now(): Instant = Clock.System.now() + 25.hours
+        }
+        val cache = PackDefinitionCache(repo, loadBundled, staleClock)
+
+        val packs = cache.getAllPacks()
+
+        assertEquals(1, packs.size)
+    }
+
+    @Test
+    fun seedFromBundled_storesPacks() = runTest {
+        val repo = FakePackDefinitionRepository()
+        val cache = PackDefinitionCache(repo, loadBundled)
+
+        val seeded = cache.seedFromBundled()
+
+        assertEquals(1, seeded.size)
+        val fromRepo = repo.getAllPacks().getOrNull()
+        assertNotNull(fromRepo)
+        assertEquals(1, fromRepo.size)
+    }
+}

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/crypto/KBJWTBuilderTest.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/crypto/KBJWTBuilderTest.kt
@@ -67,9 +67,7 @@ class KBJWTBuilderTest {
     }
 
     private fun decodeJwtPart(base64url: String): String {
-        val padded = base64url + "=".repeat((4 - base64url.length % 4) % 4)
-        val standard = padded.replace('-', '+').replace('_', '/')
-        return base64Decode(standard).decodeToString()
+        return Base64Url.decode(base64url).decodeToString()
     }
 
     // ── computeSDHash ──

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/crypto/SDJWTParserTest.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/crypto/SDJWTParserTest.kt
@@ -11,10 +11,7 @@ class SDJWTParserTest {
     // Helper: base64url-encode a disclosure array [salt, claimName, value]
     private fun encodeDisclosure(salt: String, claim: String, value: String): String {
         val json = """["$salt","$claim","$value"]"""
-        return json.encodeToByteArray().toBase64()
-            .replace('+', '-')
-            .replace('/', '_')
-            .trimEnd('=')
+        return Base64Url.encode(json.encodeToByteArray())
     }
 
     private val issuerJwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJkaWQ6d2ViOmlzc3VlciJ9.sig"

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/verification/FreshnessCheckerTest.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/verification/FreshnessCheckerTest.kt
@@ -1,0 +1,55 @@
+package id.cachet.wallet.domain.verification
+
+import kotlin.time.Clock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FreshnessCheckerTest {
+
+    private val now = Clock.System.now().epochSeconds
+
+    @Test
+    fun fresh_credential() {
+        val iat = now - 3600 // 1 hour ago
+        val exp = now + 86400 // expires tomorrow
+        assertEquals("ok", FreshnessChecker.check(iat, exp))
+    }
+
+    @Test
+    fun expired_credential() {
+        val iat = now - 3600
+        val exp = now - 60 // expired 1 minute ago
+        assertEquals("expired", FreshnessChecker.check(iat, exp))
+    }
+
+    @Test
+    fun stale_credential() {
+        val iat = now - (91L * 24 * 60 * 60) // 91 days ago
+        val exp = now + (365L * 24 * 60 * 60) // expires in a year
+        assertEquals("stale", FreshnessChecker.check(iat, exp))
+    }
+
+    @Test
+    fun no_expiration() {
+        val iat = now - 3600
+        assertEquals("ok", FreshnessChecker.check(iat, null))
+    }
+
+    @Test
+    fun no_issuance_date() {
+        val exp = now + 86400
+        assertEquals("ok", FreshnessChecker.check(null, exp))
+    }
+
+    @Test
+    fun both_null() {
+        assertEquals("ok", FreshnessChecker.check(null, null))
+    }
+
+    @Test
+    fun expired_takes_precedence_over_stale() {
+        val iat = now - (100L * 24 * 60 * 60) // 100 days ago (stale)
+        val exp = now - 60 // also expired
+        assertEquals("expired", FreshnessChecker.check(iat, exp))
+    }
+}

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/verification/IssuerMatcherTest.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/verification/IssuerMatcherTest.kt
@@ -1,0 +1,49 @@
+package id.cachet.wallet.domain.verification
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class IssuerMatcherTest {
+
+    @Test
+    fun exactMatch() {
+        assertTrue(IssuerMatcher.matches("did:veriff:production", listOf("did:veriff:production")))
+    }
+
+    @Test
+    fun wildcardMatch() {
+        assertTrue(IssuerMatcher.matches("did:veriff:production", listOf("did:veriff:*")))
+    }
+
+    @Test
+    fun wildcardMatchPrefix() {
+        assertTrue(IssuerMatcher.matches("did:checks:germany-eu", listOf("did:checks:*-eu")))
+    }
+
+    @Test
+    fun noMatch() {
+        assertFalse(IssuerMatcher.matches("did:other:something", listOf("did:veriff:*")))
+    }
+
+    @Test
+    fun emptyPatterns() {
+        assertFalse(IssuerMatcher.matches("did:veriff:production", emptyList()))
+    }
+
+    @Test
+    fun multiplePatterns_firstMatches() {
+        assertTrue(IssuerMatcher.matches("did:veriff:x", listOf("did:veriff:x", "did:other:*")))
+    }
+
+    @Test
+    fun multiplePatterns_secondMatches() {
+        assertTrue(IssuerMatcher.matches("did:other:y", listOf("did:veriff:x", "did:other:*")))
+    }
+
+    @Test
+    fun wildcardOnlyAsterisk() {
+        // Pattern "*" matches everything — the prefix is ""
+        assertTrue(IssuerMatcher.matches("anything", listOf("*")))
+    }
+}

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/verification/PredicateEvaluatorTest.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/verification/PredicateEvaluatorTest.kt
@@ -1,0 +1,193 @@
+package id.cachet.wallet.domain.verification
+
+import id.cachet.wallet.domain.model.PackBadge
+import id.cachet.wallet.domain.model.PackDefinition
+import id.cachet.wallet.domain.model.PackPredicate
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PredicateEvaluatorTest {
+
+    private fun makePack(vararg predicates: PackPredicate) = PackDefinition(
+        id = "test.pack",
+        version = "0.1.0",
+        name = "Test Pack",
+        purpose = "Testing",
+        jurisdictions = listOf("GLOBAL"),
+        badge = PackBadge(label = "Test Badge", ttl = "P90D", jurisdiction = "GLOBAL"),
+        predicates = predicates.toList()
+    )
+
+    private fun makeClaims(issuer: String, vararg pairs: Pair<String, Any>) = VerifiedClaims(
+        issuer = issuer,
+        claims = pairs.associate { (k, v) ->
+            k to when (v) {
+                is Boolean -> JsonPrimitive(v)
+                is Int -> JsonPrimitive(v)
+                is Double -> JsonPrimitive(v)
+                is String -> JsonPrimitive(v)
+                else -> JsonPrimitive(v.toString())
+            }
+        }
+    )
+
+    @Test
+    fun boolean_satisfied() {
+        val pack = makePack(
+            PackPredicate("p1", "verified", "boolean", JsonPrimitive(true), listOf("did:veriff:*"), "sd-jwt")
+        )
+        val claims = listOf(makeClaims("did:veriff:prod", "verified" to true))
+        val result = PredicateEvaluator.evaluate(pack, claims)
+
+        assertEquals(1, result.predicateResults.size)
+        assertEquals("satisfied", result.predicateResults[0].status)
+        assertTrue(result.summary.cachetGranted)
+    }
+
+    @Test
+    fun boolean_failed() {
+        val pack = makePack(
+            PackPredicate("p1", "verified", "boolean", JsonPrimitive(true), listOf("did:veriff:*"), "sd-jwt")
+        )
+        val claims = listOf(makeClaims("did:veriff:prod", "verified" to false))
+        val result = PredicateEvaluator.evaluate(pack, claims)
+
+        assertEquals("failed", result.predicateResults[0].status)
+        assertFalse(result.summary.cachetGranted)
+    }
+
+    @Test
+    fun greaterThanEqual_satisfied() {
+        val pack = makePack(
+            PackPredicate("age", "age", ">=", JsonPrimitive(18), listOf("did:veriff:*"), "sd-jwt")
+        )
+        val claims = listOf(makeClaims("did:veriff:prod", "age" to 21))
+        val result = PredicateEvaluator.evaluate(pack, claims)
+
+        assertEquals("satisfied", result.predicateResults[0].status)
+    }
+
+    @Test
+    fun greaterThanEqual_exact() {
+        val pack = makePack(
+            PackPredicate("age", "age", ">=", JsonPrimitive(18), listOf("did:veriff:*"), "sd-jwt")
+        )
+        val claims = listOf(makeClaims("did:veriff:prod", "age" to 18))
+        val result = PredicateEvaluator.evaluate(pack, claims)
+
+        assertEquals("satisfied", result.predicateResults[0].status)
+    }
+
+    @Test
+    fun greaterThanEqual_failed() {
+        val pack = makePack(
+            PackPredicate("age", "age", ">=", JsonPrimitive(18), listOf("did:veriff:*"), "sd-jwt")
+        )
+        val claims = listOf(makeClaims("did:veriff:prod", "age" to 16))
+        val result = PredicateEvaluator.evaluate(pack, claims)
+
+        assertEquals("failed", result.predicateResults[0].status)
+    }
+
+    @Test
+    fun issuer_mismatch_noCredential() {
+        val pack = makePack(
+            PackPredicate("p1", "verified", "boolean", JsonPrimitive(true), listOf("did:veriff:*"), "sd-jwt")
+        )
+        val claims = listOf(makeClaims("did:other:something", "verified" to true))
+        val result = PredicateEvaluator.evaluate(pack, claims)
+
+        assertEquals("no_credential", result.predicateResults[0].status)
+    }
+
+    @Test
+    fun empty_claims() {
+        val pack = makePack(
+            PackPredicate("p1", "verified", "boolean", JsonPrimitive(true), listOf("did:veriff:*"), "sd-jwt")
+        )
+        val result = PredicateEvaluator.evaluate(pack, emptyList())
+
+        assertEquals("no_credential", result.predicateResults[0].status)
+    }
+
+    @Test
+    fun missing_claim_noCredential() {
+        val pack = makePack(
+            PackPredicate("p1", "missing_claim", "boolean", JsonPrimitive(true), listOf("did:veriff:*"), "sd-jwt")
+        )
+        val claims = listOf(makeClaims("did:veriff:prod", "verified" to true))
+        val result = PredicateEvaluator.evaluate(pack, claims)
+
+        assertEquals("no_credential", result.predicateResults[0].status)
+    }
+
+    @Test
+    fun required_and_optional_counts() {
+        val pack = makePack(
+            PackPredicate("p1", "verified", "boolean", JsonPrimitive(true), listOf("did:veriff:*"), "sd-jwt", required = true),
+            PackPredicate("p2", "optional_claim", "boolean", JsonPrimitive(true), listOf("did:veriff:*"), "sd-jwt", required = false)
+        )
+        val claims = listOf(makeClaims("did:veriff:prod", "verified" to true))
+        val result = PredicateEvaluator.evaluate(pack, claims)
+
+        assertEquals(1, result.summary.requiredTotal)
+        assertEquals(1, result.summary.requiredSatisfied)
+        assertEquals(1, result.summary.optionalTotal)
+        assertEquals(0, result.summary.optionalSatisfied)
+        assertTrue(result.summary.cachetGranted) // all required satisfied
+    }
+
+    @Test
+    fun equalEqual_operator() {
+        val pack = makePack(
+            PackPredicate("p1", "nationality", "==", JsonPrimitive("EE"), listOf("did:veriff:*"), "sd-jwt")
+        )
+        val claims = listOf(makeClaims("did:veriff:prod", "nationality" to "EE"))
+        val result = PredicateEvaluator.evaluate(pack, claims)
+
+        assertEquals("satisfied", result.predicateResults[0].status)
+    }
+
+    @Test
+    fun lessThan_operator() {
+        val pack = makePack(
+            PackPredicate("p1", "score", "<", JsonPrimitive(100), listOf("did:veriff:*"), "sd-jwt")
+        )
+        val claims = listOf(makeClaims("did:veriff:prod", "score" to 50))
+        val result = PredicateEvaluator.evaluate(pack, claims)
+
+        assertEquals("satisfied", result.predicateResults[0].status)
+    }
+
+    @Test
+    fun identity_basic_pack_full() {
+        val pack = PackDefinition(
+            id = "pack.identity.basic",
+            version = "0.1.0",
+            name = "Identity Verification",
+            purpose = "Verify core identity attributes",
+            jurisdictions = listOf("GLOBAL"),
+            badge = PackBadge(label = "Identity Verified", ttl = "P180D", jurisdiction = "GLOBAL"),
+            predicates = listOf(
+                PackPredicate("age.ge.18", "age", ">=", JsonPrimitive(18), listOf("did:veriff:*"), "sd-jwt"),
+                PackPredicate("identity.verified", "verified", "boolean", JsonPrimitive(true), listOf("did:veriff:*"), "sd-jwt"),
+                PackPredicate("liveness.verified", "liveness_verified", "boolean", JsonPrimitive(true), listOf("did:veriff:*"), "sd-jwt")
+            )
+        )
+        val claims = listOf(makeClaims(
+            "did:veriff:production",
+            "age" to 25,
+            "verified" to true,
+            "liveness_verified" to true
+        ))
+        val result = PredicateEvaluator.evaluate(pack, claims)
+
+        assertEquals(3, result.predicateResults.size)
+        assertTrue(result.predicateResults.all { it.status == "satisfied" })
+        assertTrue(result.summary.cachetGranted)
+        assertEquals("Identity Verified", pack.badge.label)
+    }
+}

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/FakeDIDDocumentRepository.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/FakeDIDDocumentRepository.kt
@@ -1,0 +1,22 @@
+package id.cachet.wallet.testfixtures
+
+import id.cachet.wallet.domain.repository.CachedDIDDocument
+import id.cachet.wallet.domain.repository.DIDDocumentRepository
+
+class FakeDIDDocumentRepository : DIDDocumentRepository {
+    private val documents = mutableMapOf<String, CachedDIDDocument>()
+
+    override suspend fun getDocument(did: String): Result<CachedDIDDocument?> {
+        return Result.success(documents[did])
+    }
+
+    override suspend fun storeDocument(did: String, documentJson: String, fetchedAt: Long): Result<Unit> {
+        documents[did] = CachedDIDDocument(did, documentJson, fetchedAt)
+        return Result.success(Unit)
+    }
+
+    override suspend fun deleteExpired(cutoffEpochMs: Long): Result<Unit> {
+        documents.entries.removeAll { it.value.fetchedAt < cutoffEpochMs }
+        return Result.success(Unit)
+    }
+}

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/FakePackDefinitionRepository.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/FakePackDefinitionRepository.kt
@@ -1,0 +1,41 @@
+package id.cachet.wallet.testfixtures
+
+import id.cachet.wallet.domain.model.PackDefinition
+import id.cachet.wallet.domain.repository.PackDefinitionRepository
+
+class FakePackDefinitionRepository : PackDefinitionRepository {
+    private val packs = mutableMapOf<String, PackDefinition>()
+    private var fetchedAt: Long? = null
+
+    override suspend fun getPackById(packId: String): Result<PackDefinition?> {
+        return Result.success(packs[packId])
+    }
+
+    override suspend fun getAllPacks(): Result<List<PackDefinition>> {
+        return Result.success(packs.values.toList())
+    }
+
+    override suspend fun storePack(pack: PackDefinition): Result<Unit> {
+        packs[pack.id] = pack
+        fetchedAt = kotlin.time.Clock.System.now().toEpochMilliseconds()
+        return Result.success(Unit)
+    }
+
+    override suspend fun storeAll(packs: List<PackDefinition>): Result<Unit> {
+        for (pack in packs) {
+            this.packs[pack.id] = pack
+        }
+        fetchedAt = kotlin.time.Clock.System.now().toEpochMilliseconds()
+        return Result.success(Unit)
+    }
+
+    override suspend fun deleteAll(): Result<Unit> {
+        packs.clear()
+        fetchedAt = null
+        return Result.success(Unit)
+    }
+
+    override suspend fun getLatestFetchedAt(): Result<Long?> {
+        return Result.success(fetchedAt)
+    }
+}

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/FakeStatusListRepository.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/FakeStatusListRepository.kt
@@ -1,0 +1,22 @@
+package id.cachet.wallet.testfixtures
+
+import id.cachet.wallet.domain.repository.CachedStatusList
+import id.cachet.wallet.domain.repository.StatusListRepository
+
+class FakeStatusListRepository : StatusListRepository {
+    private val lists = mutableMapOf<String, CachedStatusList>()
+
+    override suspend fun getStatusList(url: String): Result<CachedStatusList?> {
+        return Result.success(lists[url])
+    }
+
+    override suspend fun storeStatusList(url: String, encodedList: String, fetchedAt: Long): Result<Unit> {
+        lists[url] = CachedStatusList(url, encodedList, fetchedAt)
+        return Result.success(Unit)
+    }
+
+    override suspend fun deleteExpired(cutoffEpochMs: Long): Result<Unit> {
+        lists.entries.removeAll { it.value.fetchedAt < cutoffEpochMs }
+        return Result.success(Unit)
+    }
+}

--- a/mobile/shared/src/iosMain/kotlin/id/cachet/wallet/domain/cache/BundledPackLoader.ios.kt
+++ b/mobile/shared/src/iosMain/kotlin/id/cachet/wallet/domain/cache/BundledPackLoader.ios.kt
@@ -1,0 +1,36 @@
+package id.cachet.wallet.domain.cache
+
+import id.cachet.wallet.domain.model.PackDefinition
+import kotlinx.serialization.json.Json
+import platform.Foundation.NSBundle
+import platform.Foundation.NSString
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.stringWithContentsOfFile
+
+@OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+actual class BundledPackLoader {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    actual fun loadBundledPacks(): List<PackDefinition> {
+        val bundle = NSBundle.mainBundle
+        val packNames = listOf(
+            "identity-basic",
+            "safe-seller.base",
+            "childcare-readiness.base",
+            "childcare-readiness.ee",
+            "childcare-readiness.es",
+            "childcare-readiness.fr"
+        )
+        return packNames.mapNotNull { name ->
+            try {
+                val path = bundle.pathForResource(name, "json") ?: return@mapNotNull null
+                val content = NSString.stringWithContentsOfFile(path, NSUTF8StringEncoding, null)
+                    ?: return@mapNotNull null
+                json.decodeFromString<PackDefinition>(content)
+            } catch (e: Exception) {
+                null
+            }
+        }
+    }
+}

--- a/mobile/shared/src/iosMain/kotlin/id/cachet/wallet/domain/cache/GzipDecompressor.ios.kt
+++ b/mobile/shared/src/iosMain/kotlin/id/cachet/wallet/domain/cache/GzipDecompressor.ios.kt
@@ -1,0 +1,6 @@
+package id.cachet.wallet.domain.cache
+
+actual fun gzipDecompress(compressed: ByteArray): ByteArray {
+    // iOS gzip decompression stub — StatusList revocation check will be skipped on iOS
+    throw UnsupportedOperationException("Gzip decompression not yet implemented for iOS")
+}

--- a/mobile/shared/src/iosMain/kotlin/id/cachet/wallet/domain/crypto/JWSVerifier.ios.kt
+++ b/mobile/shared/src/iosMain/kotlin/id/cachet/wallet/domain/crypto/JWSVerifier.ios.kt
@@ -8,4 +8,8 @@ actual class JWSVerifier actual constructor() {
     actual fun verify(jwsCompact: String, publicKeyJWK: String): String {
         throw UnsupportedOperationException("JWS verification not yet implemented for iOS")
     }
+
+    actual fun verifyJWS(jwsCompact: String, publicKeyJWK: String, expectedTyp: String?): String {
+        throw UnsupportedOperationException("JWS verification not yet implemented for iOS")
+    }
 }


### PR DESCRIPTION
## Summary

- **Phase 1 — Cache layer**: SQLite-backed caches for pack definitions (24h TTL + bundled fallback), DID documents (24h TTL), and StatusList2021 bitstrings (5-min TTL). Pack JSON files bundled as Android assets for zero-network-required first launch.
- **Phase 2 — Local SD-JWT verification**: Full 11-step verification pipeline ported from Go backend (`sdjwt_parser.go`, `evaluator.go`, `kbjwt.go`). Includes issuer signature verification, disclosure hash validation, KB-JWT holder binding, predicate evaluation (all 6 operators), freshness checks, and revocation checking.
- **Integration**: `VerificationUseCase.awaitAndVerifyRelayResponse()` now attempts local verification first, falling back to backend only when pack definitions aren't cached.
- **Consolidation**: 4 scattered base64url implementations unified into `Base64Url` utility.

Closes #99 (Phase 1 + Phase 2; Phases 3-4 tracked separately)

## Test plan

- [ ] `compileCommonMainKotlinMetadata` passes (verified)
- [ ] `compileKotlinIosSimulatorArm64` passes (verified)
- [ ] Unit tests: IssuerMatcherTest, FreshnessCheckerTest, PredicateEvaluatorTest, PackDefinitionCacheTest
- [ ] `assembleDebug` on Android with SDK configured
- [ ] Manual: verify credential with backend running — same result as before
- [ ] Manual: kill backend, verify previously-cached credential type — local verification works
- [ ] Manual: fresh install — bundled packs available without network

🤖 Generated with [Claude Code](https://claude.com/claude-code)