### PR TITLE
feat: offline queue and sync — retry failed operations on reconnect

### DIFF
--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/connectivity/AndroidConnectivityObserver.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/connectivity/AndroidConnectivityObserver.kt
@@ -1,0 +1,47 @@
+package id.cachet.wallet.android.connectivity
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import id.cachet.wallet.domain.sync.ConnectivityObserver
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class AndroidConnectivityObserver(context: Context) : ConnectivityObserver {
+
+    private val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    private val _isOnline = MutableStateFlow(checkCurrentConnectivity())
+    override val isOnline: StateFlow<Boolean> = _isOnline.asStateFlow()
+
+    private val callback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            _isOnline.value = true
+        }
+
+        override fun onLost(network: Network) {
+            _isOnline.value = false
+        }
+
+        override fun onCapabilitiesChanged(network: Network, caps: NetworkCapabilities) {
+            _isOnline.value = caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        }
+    }
+
+    init {
+        val request = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+        connectivityManager.registerNetworkCallback(request, callback)
+    }
+
+    private fun checkCurrentConnectivity(): Boolean {
+        val activeNetwork = connectivityManager.activeNetwork ?: return false
+        val caps = connectivityManager.getNetworkCapabilities(activeNetwork) ?: return false
+        return caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+}

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/di/AndroidModule.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/di/AndroidModule.kt
@@ -3,6 +3,7 @@ package id.cachet.wallet.android.di
 import androidx.sqlite.db.SupportSQLiteDatabase
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
+import id.cachet.wallet.android.connectivity.AndroidConnectivityObserver
 import id.cachet.wallet.android.data.CredentialRepositoryImpl
 import id.cachet.wallet.android.ui.WalletViewModel
 import id.cachet.wallet.android.BuildConfig
@@ -14,6 +15,7 @@ import id.cachet.wallet.domain.crypto.AndroidKeyStoreKeyManager
 import id.cachet.wallet.domain.crypto.EphemeralKeyGenerator
 import id.cachet.wallet.domain.crypto.KeyManager
 import id.cachet.wallet.domain.repository.CredentialRepository
+import id.cachet.wallet.domain.sync.ConnectivityObserver
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
@@ -50,6 +52,9 @@ val androidModule = module {
     // Bundled pack definitions from assets
     single { BundledPackLoader(androidContext()) }
 
+    // Connectivity observation for offline sync
+    single<ConnectivityObserver> { AndroidConnectivityObserver(androidContext()) }
+
     // Verification — demo uses MockVeriffService, prod uses NoOpVeriffService (until real SDK)
     single<VeriffService> {
         if (BuildConfig.DEMO_ENABLED) {
@@ -68,6 +73,8 @@ val androidModule = module {
             veriffService = get(),
             consentUseCase = get(),
             verificationUseCase = get(),
+            syncManager = get(),
+            connectivityObserver = get(),
             demoModeParam = params.get<Boolean>(0),
             demoEmpty = params.get<Boolean>(1)
         )

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/WalletViewModel.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/WalletViewModel.kt
@@ -17,6 +17,9 @@ import id.cachet.wallet.domain.model.ConsentDetails
 import id.cachet.wallet.domain.model.ConsentReceipt
 import id.cachet.wallet.domain.model.PresentationRequest
 import id.cachet.wallet.domain.model.VerifiableCredential
+import id.cachet.wallet.domain.sync.ConnectivityObserver
+import id.cachet.wallet.domain.sync.SyncManager
+import id.cachet.wallet.domain.sync.SyncStatus
 import id.cachet.wallet.domain.usecase.ConsentUseCase
 import id.cachet.wallet.domain.usecase.IssuanceUseCase
 import id.cachet.wallet.domain.usecase.VerificationUseCase
@@ -33,6 +36,8 @@ class WalletViewModel(
     private val veriffService: VeriffService,
     private val consentUseCase: ConsentUseCase,
     private val verificationUseCase: VerificationUseCase,
+    private val syncManager: SyncManager,
+    private val connectivityObserver: ConnectivityObserver,
     private val demoModeParam: Boolean = false,
     private val demoEmpty: Boolean = false
 ) : ViewModel() {
@@ -49,6 +54,15 @@ class WalletViewModel(
     private val _activityState = MutableStateFlow(ActivityUiState())
     val activityState: StateFlow<ActivityUiState> = _activityState.asStateFlow()
 
+    /** Network connectivity exposed to UI for status indicator. */
+    val isOnline: StateFlow<Boolean> = connectivityObserver.isOnline
+
+    /** Pending sync items count for badge/indicator. */
+    val pendingSyncCount: StateFlow<Int> = syncManager.pendingCount
+
+    /** Sync status for progress indicator. */
+    val syncStatus: StateFlow<SyncStatus> = syncManager.syncStatus
+
     /** Active verifier session -- set when QR overlay is shown, consumed when verification completes. */
     private var activeVerifierSession: VerifierSessionInfo? = null
 
@@ -64,6 +78,7 @@ class WalletViewModel(
             loadCredentials()
             loadActivity()
         }
+        syncManager.start()
     }
 
     // -- Relay flow --

--- a/mobile/androidApp/src/test/kotlin/id/cachet/wallet/android/ui/VerificationActivityIntegrationTest.kt
+++ b/mobile/androidApp/src/test/kotlin/id/cachet/wallet/android/ui/VerificationActivityIntegrationTest.kt
@@ -9,10 +9,15 @@ import id.cachet.wallet.domain.model.*
 import id.cachet.wallet.domain.repository.CredentialRepository
 import id.cachet.wallet.domain.repository.InMemoryConsentReceiptRepository
 import id.cachet.wallet.domain.repository.MockTransparencyLogRepository
+import id.cachet.wallet.domain.sync.ConnectivityObserver
+import id.cachet.wallet.domain.sync.SyncManager
+import id.cachet.wallet.domain.sync.SyncQueueRepository
 import id.cachet.wallet.domain.usecase.ConsentUseCase
 import id.cachet.wallet.domain.usecase.IssuanceUseCase
 import id.cachet.wallet.domain.usecase.VerificationUseCase
 import id.cachet.wallet.network.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -125,11 +130,15 @@ class VerificationActivityIntegrationTest {
             relayClient = relayClient,
             consentUseCase = consentUseCase
         )
+        val connectivity = StubConnectivityObserver()
+        val openIdClient = NoOpOpenID4VCIClient()
         val vm = WalletViewModel(
-            issuanceUseCase = IssuanceUseCase(credRepo, NoOpOpenID4VCIClient()),
+            issuanceUseCase = IssuanceUseCase(credRepo, openIdClient),
             veriffService = NoOpVeriffService(),
             consentUseCase = consentUseCase,
             verificationUseCase = verificationUseCase,
+            syncManager = SyncManager(connectivity, StubSyncQueueRepository(), InMemoryConsentReceiptRepository(), MockTransparencyLogRepository(), openIdClient, credRepo),
+            connectivityObserver = connectivity,
             demoModeParam = true,
             demoEmpty = false
         )
@@ -223,13 +232,17 @@ class VerificationActivityIntegrationTest {
             val credRepo = FakeCredRepo()
             val receiptRepo = InMemoryConsentReceiptRepository()
             val consentUseCase = ConsentUseCase(credRepo, receiptRepo, MockTransparencyLogRepository())
+            val connectivity = StubConnectivityObserver()
+            val openIdClient = NoOpOpenID4VCIClient()
             val vm = WalletViewModel(
-                issuanceUseCase = IssuanceUseCase(credRepo, NoOpOpenID4VCIClient()),
+                issuanceUseCase = IssuanceUseCase(credRepo, openIdClient),
                 veriffService = NoOpVeriffService(),
                 consentUseCase = consentUseCase,
                 verificationUseCase = VerificationUseCase(
                     credRepo, ConfigurableVerifierClient(), ConfigurableRelayClient(), consentUseCase
                 ),
+                syncManager = SyncManager(connectivity, StubSyncQueueRepository(), InMemoryConsentReceiptRepository(), MockTransparencyLogRepository(), openIdClient, credRepo),
+                connectivityObserver = connectivity,
                 demoModeParam = true,
                 demoEmpty = false
             )
@@ -295,9 +308,13 @@ private class NoOpOpenID4VCIClient : OpenID4VCIClient {
         TokenResponse(access_token = "tok", token_type = "Bearer", expires_in = 3600, scope = "openid")
     override suspend fun requestCredential(accessToken: String, format: String, types: List<String>): CredentialResponse =
         throw OpenID4VCIException("stub")
-    override suspend fun requestSDJWTCredential(accessToken: String, types: List<String>, holderJWK: String): SDJWTCredentialResponse =
+    override suspend fun requestSDJWTCredential(accessToken: String, types: List<String>, holderJWK: String, proofJWT: String?): SDJWTCredentialResponse =
         throw OpenID4VCIException("stub")
+    override suspend fun requestNonce(): NonceResponse =
+        NonceResponse(c_nonce = "noop-nonce", c_nonce_expires_in = 300)
 }
+
+// StubConnectivityObserver and StubSyncQueueRepository defined in WalletViewModelTest.kt
 
 private class NoOpVeriffService : VeriffService {
     override suspend fun startVerification(): VeriffResult = VeriffResult.Cancelled

--- a/mobile/androidApp/src/test/kotlin/id/cachet/wallet/android/ui/WalletViewModelTest.kt
+++ b/mobile/androidApp/src/test/kotlin/id/cachet/wallet/android/ui/WalletViewModelTest.kt
@@ -10,10 +10,15 @@ import id.cachet.wallet.domain.model.*
 import id.cachet.wallet.domain.repository.CredentialRepository
 import id.cachet.wallet.domain.repository.InMemoryConsentReceiptRepository
 import id.cachet.wallet.domain.repository.MockTransparencyLogRepository
+import id.cachet.wallet.domain.sync.ConnectivityObserver
+import id.cachet.wallet.domain.sync.SyncManager
+import id.cachet.wallet.domain.sync.SyncQueueRepository
 import id.cachet.wallet.domain.usecase.ConsentUseCase
 import id.cachet.wallet.domain.usecase.IssuanceUseCase
 import id.cachet.wallet.domain.usecase.VerificationUseCase
 import id.cachet.wallet.network.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -60,11 +65,22 @@ class WalletViewModelTest {
         )
         val veriffService = FakeVeriffService(veriffResult)
 
+        val connectivity = StubConnectivityObserver()
+        val syncManager = SyncManager(
+            connectivity = connectivity,
+            queueRepository = StubSyncQueueRepository(),
+            consentReceiptRepository = InMemoryConsentReceiptRepository(),
+            transparencyLogRepository = MockTransparencyLogRepository(),
+            openID4VCIClient = openIdClient,
+            credentialRepository = credRepo
+        )
         return WalletViewModel(
             issuanceUseCase = issuanceUseCase,
             veriffService = veriffService,
             consentUseCase = consentUseCase,
             verificationUseCase = verificationUseCase,
+            syncManager = syncManager,
+            connectivityObserver = connectivity,
             demoModeParam = false,
             demoEmpty = demoEmpty
         )
@@ -112,11 +128,16 @@ class WalletViewModelTest {
     @Test
     fun `startVeriffVerification is no-op in demo mode`() {
         val credRepo = InMemoryCredentialRepository()
+        val connectivity = StubConnectivityObserver()
+        val openIdClient = StubOpenID4VCIClient()
+        val consentUseCase = ConsentUseCase(credRepo, InMemoryConsentReceiptRepository(), MockTransparencyLogRepository())
         val vm = WalletViewModel(
-            issuanceUseCase = IssuanceUseCase(credRepo, StubOpenID4VCIClient()),
+            issuanceUseCase = IssuanceUseCase(credRepo, openIdClient),
             veriffService = FakeVeriffService(VeriffResult.Success("s1")),
-            consentUseCase = ConsentUseCase(credRepo, InMemoryConsentReceiptRepository(), MockTransparencyLogRepository()),
-            verificationUseCase = VerificationUseCase(credRepo, StubVerifierClient(), StubRelayClient(), ConsentUseCase(credRepo, InMemoryConsentReceiptRepository(), MockTransparencyLogRepository())),
+            consentUseCase = consentUseCase,
+            verificationUseCase = VerificationUseCase(credRepo, StubVerifierClient(), StubRelayClient(), consentUseCase),
+            syncManager = SyncManager(connectivity, StubSyncQueueRepository(), InMemoryConsentReceiptRepository(), MockTransparencyLogRepository(), openIdClient, credRepo),
+            connectivityObserver = connectivity,
             demoModeParam = true,
             demoEmpty = false
         )
@@ -182,11 +203,15 @@ class WalletViewModelTest {
 
         val consentRepo = InMemoryConsentReceiptRepository()
         val consentUseCase = ConsentUseCase(credRepo, consentRepo, MockTransparencyLogRepository())
+        val connectivity = StubConnectivityObserver()
+        val openIdClient = StubOpenID4VCIClient()
         val vm = WalletViewModel(
-            issuanceUseCase = IssuanceUseCase(credRepo, StubOpenID4VCIClient()),
+            issuanceUseCase = IssuanceUseCase(credRepo, openIdClient),
             veriffService = FakeVeriffService(VeriffResult.Success("s1")),
             consentUseCase = consentUseCase,
             verificationUseCase = VerificationUseCase(credRepo, StubVerifierClient(), StubRelayClient(), consentUseCase),
+            syncManager = SyncManager(connectivity, StubSyncQueueRepository(), InMemoryConsentReceiptRepository(), MockTransparencyLogRepository(), openIdClient, credRepo),
+            connectivityObserver = connectivity,
             demoModeParam = true,
             demoEmpty = false
         )
@@ -220,11 +245,15 @@ class WalletViewModelTest {
         val credRepo = InMemoryCredentialRepository()
         val consentRepo = InMemoryConsentReceiptRepository()
         val consentUseCase = ConsentUseCase(credRepo, consentRepo, MockTransparencyLogRepository())
+        val connectivity = StubConnectivityObserver()
+        val openIdClient = StubOpenID4VCIClient()
         val vm = WalletViewModel(
-            issuanceUseCase = IssuanceUseCase(credRepo, StubOpenID4VCIClient()),
+            issuanceUseCase = IssuanceUseCase(credRepo, openIdClient),
             veriffService = FakeVeriffService(VeriffResult.Success("s1")),
             consentUseCase = consentUseCase,
             verificationUseCase = VerificationUseCase(credRepo, StubVerifierClient(), StubRelayClient(), consentUseCase),
+            syncManager = SyncManager(connectivity, StubSyncQueueRepository(), InMemoryConsentReceiptRepository(), MockTransparencyLogRepository(), openIdClient, credRepo),
+            connectivityObserver = connectivity,
             demoModeParam = true,
             demoEmpty = false
         )
@@ -276,8 +305,26 @@ private class StubOpenID4VCIClient : OpenID4VCIClient {
         TokenResponse(access_token = "tok", token_type = "Bearer", expires_in = 3600, scope = "openid")
     override suspend fun requestCredential(accessToken: String, format: String, types: List<String>): CredentialResponse =
         throw OpenID4VCIException("no session in stub")
-    override suspend fun requestSDJWTCredential(accessToken: String, types: List<String>, holderJWK: String): SDJWTCredentialResponse =
+    override suspend fun requestSDJWTCredential(accessToken: String, types: List<String>, holderJWK: String, proofJWT: String?): SDJWTCredentialResponse =
         throw OpenID4VCIException("no session in stub")
+    override suspend fun requestNonce(): NonceResponse =
+        NonceResponse(c_nonce = "stub-nonce", c_nonce_expires_in = 300)
+}
+
+internal class StubConnectivityObserver : ConnectivityObserver {
+    override val isOnline: StateFlow<Boolean> = MutableStateFlow(true)
+}
+
+internal class StubSyncQueueRepository : SyncQueueRepository {
+    override suspend fun getPendingAnchorings() = emptyList<SyncQueueRepository.PendingAnchoringItem>()
+    override suspend fun deletePendingAnchoring(receiptId: String) {}
+    override suspend fun updatePendingAnchoringStatus(receiptId: String, status: String, retryCount: Long, lastAttemptAt: Long) {}
+    override suspend fun deleteExpiredIssuances(nowMillis: Long) {}
+    override suspend fun getPendingIssuances() = emptyList<SyncQueueRepository.PendingIssuanceItem>()
+    override suspend fun deletePendingIssuance(id: String) {}
+    override suspend fun updatePendingIssuanceStatus(id: String, status: String, retryCount: Long, lastAttemptAt: Long) {}
+    override suspend fun getPendingAnchoringCount() = 0
+    override suspend fun getPendingIssuanceCount() = 0
 }
 
 private class StubVerifierClient : VerifierClient {

--- a/mobile/shared/build.gradle.kts
+++ b/mobile/shared/build.gradle.kts
@@ -67,7 +67,7 @@ sqldelight {
     databases {
         create("WalletDatabase") {
             packageName.set("id.cachet.wallet.db")
-            version = 4
+            version = 5
             srcDirs("src/commonMain/sqldelight")
         }
     }

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/repository/ConsentReceiptRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/repository/ConsentReceiptRepository.kt
@@ -42,6 +42,11 @@ interface ConsentReceiptRepository {
      * Verify the integrity of all stored receipts
      */
     suspend fun verifyAllReceipts(): Result<Map<String, Boolean>>
+
+    /**
+     * Update the transparency log entry for a receipt (async anchoring on reconnect).
+     */
+    suspend fun updateTransparencyLog(receiptId: String, transparencyLogJson: String): Result<Unit>
 }
 
 /**
@@ -113,6 +118,15 @@ class InMemoryConsentReceiptRepository : ConsentReceiptRepository {
                 receipt.receiptHash != null && receipt.signature != null && receipt.salt != null
             }
             Result.success(verificationResults)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun updateTransparencyLog(receiptId: String, transparencyLogJson: String): Result<Unit> {
+        return try {
+            // In-memory: no-op (transparency log stored on receipt object directly)
+            Result.success(Unit)
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/repository/SqlDelightConsentReceiptRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/repository/SqlDelightConsentReceiptRepository.kt
@@ -99,6 +99,18 @@ class SqlDelightConsentReceiptRepository(
         }
     }
 
+    override suspend fun updateTransparencyLog(receiptId: String, transparencyLogJson: String): Result<Unit> {
+        return try {
+            database.walletDatabaseQueries.updateReceiptTransparencyLog(
+                transparency_log_json = transparencyLogJson,
+                id = receiptId
+            )
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
     private fun id.cachet.wallet.db.Consent_receipts.toConsentReceipt(): ConsentReceipt {
         return ConsentReceipt(
             id = id,

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/sync/AnchoringQueue.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/sync/AnchoringQueue.kt
@@ -1,0 +1,10 @@
+package id.cachet.wallet.domain.sync
+
+/**
+ * Queue for consent receipts that need transparency log anchoring.
+ * Receipts are enqueued when anchoring fails (e.g., offline) and
+ * drained by SyncManager when connectivity is restored.
+ */
+interface AnchoringQueue {
+    suspend fun enqueue(receiptId: String)
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/sync/ConnectivityObserver.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/sync/ConnectivityObserver.kt
@@ -1,0 +1,13 @@
+package id.cachet.wallet.domain.sync
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Observes network connectivity changes.
+ * Platform-specific implementations provide real connectivity state;
+ * tests use FakeConnectivityObserver.
+ */
+interface ConnectivityObserver {
+    /** Current connectivity state. true = online, false = offline. */
+    val isOnline: StateFlow<Boolean>
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/sync/IssuanceQueue.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/sync/IssuanceQueue.kt
@@ -1,0 +1,26 @@
+package id.cachet.wallet.domain.sync
+
+/**
+ * State persisted when credential issuance fails after token was obtained.
+ * Enables retry on reconnect without re-authenticating.
+ */
+data class PendingIssuanceState(
+    val id: String,
+    val clientId: String,
+    val credentialTypes: List<String>,
+    val format: String,
+    val sessionId: String?,
+    val accessToken: String,
+    val tokenExpiresAt: Long,
+    val keyAlias: String?,
+    val holderJwk: String?
+)
+
+/**
+ * Queue for partially-completed issuance flows.
+ * Items are enqueued when credential fetch fails after OAuth token was obtained,
+ * and drained by SyncManager when connectivity is restored.
+ */
+interface IssuanceQueue {
+    suspend fun enqueue(state: PendingIssuanceState)
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/sync/SqlDelightAnchoringQueue.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/sync/SqlDelightAnchoringQueue.kt
@@ -1,0 +1,20 @@
+package id.cachet.wallet.domain.sync
+
+import id.cachet.wallet.db.WalletDatabase
+import kotlin.time.Clock
+
+class SqlDelightAnchoringQueue(
+    private val database: WalletDatabase,
+    private val clock: Clock = Clock.System
+) : AnchoringQueue {
+
+    override suspend fun enqueue(receiptId: String) {
+        database.walletDatabaseQueries.insertPendingAnchoring(
+            receipt_id = receiptId,
+            created_at = clock.now().toEpochMilliseconds(),
+            retry_count = 0,
+            last_attempt_at = null,
+            status = "pending"
+        )
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/sync/SqlDelightIssuanceQueue.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/sync/SqlDelightIssuanceQueue.kt
@@ -1,0 +1,30 @@
+package id.cachet.wallet.domain.sync
+
+import id.cachet.wallet.db.WalletDatabase
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.time.Clock
+
+class SqlDelightIssuanceQueue(
+    private val database: WalletDatabase,
+    private val clock: Clock = Clock.System
+) : IssuanceQueue {
+
+    override suspend fun enqueue(state: PendingIssuanceState) {
+        database.walletDatabaseQueries.insertPendingIssuance(
+            id = state.id,
+            client_id = state.clientId,
+            credential_types_json = Json.encodeToString(state.credentialTypes),
+            format = state.format,
+            session_id = state.sessionId,
+            access_token = state.accessToken,
+            token_expires_at = state.tokenExpiresAt,
+            key_alias = state.keyAlias,
+            holder_jwk = state.holderJwk,
+            created_at = clock.now().toEpochMilliseconds(),
+            retry_count = 0,
+            last_attempt_at = null,
+            status = "pending"
+        )
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/sync/SqlDelightSyncQueueRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/sync/SqlDelightSyncQueueRepository.kt
@@ -1,0 +1,78 @@
+package id.cachet.wallet.domain.sync
+
+import id.cachet.wallet.db.WalletDatabase
+
+class SqlDelightSyncQueueRepository(
+    private val database: WalletDatabase
+) : SyncQueueRepository {
+
+    override suspend fun getPendingAnchorings(): List<SyncQueueRepository.PendingAnchoringItem> {
+        return database.walletDatabaseQueries.getPendingAnchorings().executeAsList().map {
+            SyncQueueRepository.PendingAnchoringItem(
+                receiptId = it.receipt_id,
+                retryCount = it.retry_count,
+                status = it.status
+            )
+        }
+    }
+
+    override suspend fun deletePendingAnchoring(receiptId: String) {
+        database.walletDatabaseQueries.deletePendingAnchoring(receiptId)
+    }
+
+    override suspend fun updatePendingAnchoringStatus(
+        receiptId: String, status: String, retryCount: Long, lastAttemptAt: Long
+    ) {
+        database.walletDatabaseQueries.updatePendingAnchoringStatus(
+            status = status,
+            retry_count = retryCount,
+            last_attempt_at = lastAttemptAt,
+            receipt_id = receiptId
+        )
+    }
+
+    override suspend fun deleteExpiredIssuances(nowMillis: Long) {
+        database.walletDatabaseQueries.deleteExpiredIssuances(nowMillis)
+    }
+
+    override suspend fun getPendingIssuances(): List<SyncQueueRepository.PendingIssuanceItem> {
+        return database.walletDatabaseQueries.getPendingIssuances().executeAsList().map {
+            SyncQueueRepository.PendingIssuanceItem(
+                id = it.id,
+                clientId = it.client_id,
+                credentialTypesJson = it.credential_types_json,
+                format = it.format,
+                sessionId = it.session_id,
+                accessToken = it.access_token,
+                tokenExpiresAt = it.token_expires_at,
+                keyAlias = it.key_alias,
+                holderJwk = it.holder_jwk,
+                retryCount = it.retry_count,
+                status = it.status
+            )
+        }
+    }
+
+    override suspend fun deletePendingIssuance(id: String) {
+        database.walletDatabaseQueries.deletePendingIssuance(id)
+    }
+
+    override suspend fun updatePendingIssuanceStatus(
+        id: String, status: String, retryCount: Long, lastAttemptAt: Long
+    ) {
+        database.walletDatabaseQueries.updatePendingIssuanceStatus(
+            status = status,
+            retry_count = retryCount,
+            last_attempt_at = lastAttemptAt,
+            id = id
+        )
+    }
+
+    override suspend fun getPendingAnchoringCount(): Int {
+        return database.walletDatabaseQueries.getPendingAnchorings().executeAsList().size
+    }
+
+    override suspend fun getPendingIssuanceCount(): Int {
+        return database.walletDatabaseQueries.getPendingIssuances().executeAsList().size
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/sync/SyncManager.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/sync/SyncManager.kt
@@ -1,0 +1,341 @@
+package id.cachet.wallet.domain.sync
+
+import id.cachet.wallet.domain.model.*
+import id.cachet.wallet.domain.repository.ConsentReceiptRepository
+import id.cachet.wallet.domain.repository.TransparencyLogRepository
+import id.cachet.wallet.domain.crypto.KeyManager
+import id.cachet.wallet.domain.repository.CredentialRepository
+import id.cachet.wallet.network.OpenID4VCIClient
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.serialization.json.Json
+import kotlin.time.Clock
+
+enum class SyncStatus { IDLE, SYNCING, ERROR }
+
+class SyncManager(
+    private val connectivity: ConnectivityObserver,
+    private val queueRepository: SyncQueueRepository,
+    private val consentReceiptRepository: ConsentReceiptRepository,
+    private val transparencyLogRepository: TransparencyLogRepository,
+    private val openID4VCIClient: OpenID4VCIClient,
+    private val credentialRepository: CredentialRepository,
+    private val keyManager: KeyManager? = null,
+    private val clock: Clock = Clock.System,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+) {
+    companion object {
+        const val MAX_RETRY_COUNT = 5
+        private const val TOKEN_EXPIRY_BUFFER_MS = 300_000L // 5 minutes
+    }
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private val drainMutex = Mutex()
+
+    private val _syncStatus = MutableStateFlow(SyncStatus.IDLE)
+    val syncStatus: StateFlow<SyncStatus> = _syncStatus.asStateFlow()
+
+    private val _pendingCount = MutableStateFlow(0)
+    val pendingCount: StateFlow<Int> = _pendingCount.asStateFlow()
+
+    /** Start observing connectivity. Call once from app startup. */
+    fun start() {
+        scope.launch {
+            connectivity.isOnline
+                .collect { online ->
+                    if (online) {
+                        drainQueues()
+                    }
+                }
+        }
+        scope.launch { refreshPendingCount() }
+    }
+
+    /** Manually trigger sync (e.g., pull-to-refresh). */
+    suspend fun triggerSync() {
+        if (connectivity.isOnline.value) {
+            drainQueues()
+        }
+    }
+
+    private suspend fun drainQueues() {
+        if (!drainMutex.tryLock()) return // already draining
+        try {
+            _syncStatus.value = SyncStatus.SYNCING
+            drainAnchoringQueue()
+            drainIssuanceQueue()
+            _syncStatus.value = SyncStatus.IDLE
+        } catch (_: Exception) {
+            _syncStatus.value = SyncStatus.ERROR
+        } finally {
+            drainMutex.unlock()
+            refreshPendingCount()
+        }
+    }
+
+    // ── Anchoring queue ──
+
+    private suspend fun drainAnchoringQueue() {
+        val pending = queueRepository.getPendingAnchorings()
+
+        for (item in pending) {
+            if (!connectivity.isOnline.value) break
+
+            val receipt = consentReceiptRepository.getReceiptById(item.receiptId)
+                .getOrNull() ?: run {
+                // Receipt was deleted — clean up queue entry
+                queueRepository.deletePendingAnchoring(item.receiptId)
+                continue
+            }
+
+            // Idempotent: if already anchored, just clean up
+            if (receipt.transparencyLogEntry != null) {
+                queueRepository.deletePendingAnchoring(item.receiptId)
+                continue
+            }
+
+            val result = tryAnchorReceipt(receipt)
+            val now = clock.now().toEpochMilliseconds()
+
+            when (result) {
+                is SyncItemResult.Success -> {
+                    queueRepository.deletePendingAnchoring(item.receiptId)
+                }
+                is SyncItemResult.Retry -> {
+                    val newCount = item.retryCount + 1
+                    val newStatus = if (newCount >= MAX_RETRY_COUNT) "failed" else "pending"
+                    queueRepository.updatePendingAnchoringStatus(
+                        receiptId = item.receiptId,
+                        status = newStatus,
+                        retryCount = newCount,
+                        lastAttemptAt = now
+                    )
+                }
+                is SyncItemResult.Failed, is SyncItemResult.Expired -> {
+                    queueRepository.updatePendingAnchoringStatus(
+                        receiptId = item.receiptId,
+                        status = "failed",
+                        retryCount = item.retryCount + 1,
+                        lastAttemptAt = now
+                    )
+                }
+            }
+        }
+    }
+
+    private suspend fun tryAnchorReceipt(receipt: ConsentReceipt): SyncItemResult {
+        return try {
+            val saltHash = receipt.salt?.let { sha256Hash(it) }
+                ?: return SyncItemResult.Failed("Receipt has no salt")
+            val receiptHash = receipt.receiptHash
+                ?: return SyncItemResult.Failed("Receipt has no hash")
+
+            val request = AddEntryRequest(
+                receiptHash = receiptHash,
+                saltHash = saltHash,
+                policyId = "consent-receipt-v1"
+            )
+
+            val response = transparencyLogRepository.submitReceiptHash(request).getOrElse {
+                return SyncItemResult.Retry(it.message ?: "Network error")
+            }
+
+            val transparencyEntry = TransparencyLogEntry(
+                logId = response.sct.logId,
+                logIndex = -1,
+                sct = response.sct,
+                anchoredAt = clock.now(),
+                isVerified = false
+            )
+
+            consentReceiptRepository.updateTransparencyLog(
+                receiptId = receipt.id,
+                transparencyLogJson = json.encodeToString(TransparencyLogEntry.serializer(), transparencyEntry)
+            )
+
+            SyncItemResult.Success
+        } catch (e: Exception) {
+            SyncItemResult.Retry(e.message ?: "Unknown error")
+        }
+    }
+
+    // ── Issuance queue ──
+
+    private suspend fun drainIssuanceQueue() {
+        // Clean up expired tokens first
+        queueRepository.deleteExpiredIssuances(clock.now().toEpochMilliseconds())
+
+        val pending = queueRepository.getPendingIssuances()
+
+        for (item in pending) {
+            if (!connectivity.isOnline.value) break
+
+            val now = clock.now().toEpochMilliseconds()
+
+            // Check token expiry with buffer
+            if (item.tokenExpiresAt - TOKEN_EXPIRY_BUFFER_MS < now) {
+                queueRepository.updatePendingIssuanceStatus(
+                    id = item.id,
+                    status = "expired",
+                    retryCount = item.retryCount,
+                    lastAttemptAt = now
+                )
+                continue
+            }
+
+            val result = tryResumeIssuance(item)
+
+            when (result) {
+                is SyncItemResult.Success -> {
+                    queueRepository.deletePendingIssuance(item.id)
+                }
+                is SyncItemResult.Expired -> {
+                    queueRepository.updatePendingIssuanceStatus(
+                        id = item.id,
+                        status = "expired",
+                        retryCount = item.retryCount + 1,
+                        lastAttemptAt = now
+                    )
+                }
+                is SyncItemResult.Retry -> {
+                    val newCount = item.retryCount + 1
+                    val newStatus = if (newCount >= MAX_RETRY_COUNT) "failed" else "pending"
+                    queueRepository.updatePendingIssuanceStatus(
+                        id = item.id,
+                        status = newStatus,
+                        retryCount = newCount,
+                        lastAttemptAt = now
+                    )
+                }
+                is SyncItemResult.Failed -> {
+                    queueRepository.updatePendingIssuanceStatus(
+                        id = item.id,
+                        status = "failed",
+                        retryCount = item.retryCount + 1,
+                        lastAttemptAt = now
+                    )
+                }
+            }
+        }
+    }
+
+    private suspend fun tryResumeIssuance(
+        item: SyncQueueRepository.PendingIssuanceItem
+    ): SyncItemResult {
+        return try {
+            val types: List<String> = json.decodeFromString(item.credentialTypesJson)
+
+            if (item.format == "vc+sd-jwt") {
+                // SD-JWT credential: needs fresh c_nonce + proof JWT
+                val cNonce = try {
+                    openID4VCIClient.requestNonce().cNonce
+                } catch (_: Exception) {
+                    null
+                }
+
+                val proofJWT = if (cNonce != null && item.keyAlias != null && keyManager != null) {
+                    id.cachet.wallet.domain.crypto.KBJWTBuilder.buildProofJWT(
+                        nonce = cNonce,
+                        audience = id.cachet.wallet.config.AppConfig.baseUrl,
+                        keyManager = keyManager,
+                        keyAlias = item.keyAlias
+                    )
+                } else null
+
+                val credentialResponse = openID4VCIClient.requestSDJWTCredential(
+                    accessToken = item.accessToken,
+                    types = types,
+                    holderJWK = item.holderJwk ?: "",
+                    proofJWT = proofJWT
+                )
+
+                val parsed = id.cachet.wallet.domain.crypto.SDJWTParser.parse(credentialResponse.credential)
+                val displayCredential = buildDisplayCredentialFromSDJWT(parsed, types)
+
+                val storedCredential = StoredCredential(
+                    localId = generateUuid(),
+                    credential = displayCredential,
+                    rawSdJwt = credentialResponse.credential,
+                    keyAlias = item.keyAlias,
+                    createdAt = clock.now(),
+                    isRevoked = false
+                )
+
+                credentialRepository.storeCredential(storedCredential)
+                SyncItemResult.Success
+            } else {
+                // Legacy JWT credential
+                val credentialResponse = openID4VCIClient.requestCredential(
+                    accessToken = item.accessToken,
+                    format = item.format,
+                    types = types
+                )
+
+                val storedCredential = StoredCredential(
+                    localId = generateUuid(),
+                    credential = credentialResponse.credential,
+                    rawJwt = null,
+                    createdAt = clock.now(),
+                    isRevoked = false
+                )
+
+                credentialRepository.storeCredential(storedCredential)
+                SyncItemResult.Success
+            }
+        } catch (e: Exception) {
+            val message = e.message ?: ""
+            if (message.contains("401") || message.contains("Unauthorized", ignoreCase = true)) {
+                SyncItemResult.Expired("Token rejected: $message")
+            } else {
+                SyncItemResult.Retry(message)
+            }
+        }
+    }
+
+    private fun buildDisplayCredentialFromSDJWT(
+        parsed: id.cachet.wallet.domain.crypto.SDJWTParser.ParsedSDJWT,
+        types: List<String>
+    ): VerifiableCredential {
+        val ageClaim = parsed.claims["age"]
+        val age = ageClaim?.toString()?.toDoubleOrNull()?.toInt()
+        val nationality = parsed.claims["nationality"]?.toString()?.removeSurrounding("\"")
+        val documentType = parsed.claims["documentType"]?.toString()?.removeSurrounding("\"")
+
+        return VerifiableCredential(
+            id = "urn:sd-jwt:${generateUuid()}",
+            context = listOf("https://www.w3.org/2018/credentials/v1"),
+            type = types,
+            issuer = "did:veriff:production",
+            issuanceDate = clock.now().toString(),
+            credentialSubject = CredentialSubject(
+                id = "did:example:holder",
+                verified = true,
+                personalData = PersonalData(
+                    age = age,
+                    nationality = nationality,
+                    documentType = documentType
+                )
+            )
+        )
+    }
+
+    private fun generateUuid(): String {
+        val random = kotlin.random.Random.Default
+        return "${random.nextInt().toString(16)}-${random.nextInt().toString(16)}-${random.nextInt().toString(16)}-${random.nextInt().toString(16)}"
+    }
+
+    internal suspend fun refreshPendingCount() {
+        val anchoringCount = queueRepository.getPendingAnchoringCount()
+        val issuanceCount = queueRepository.getPendingIssuanceCount()
+        _pendingCount.value = anchoringCount + issuanceCount
+    }
+}
+
+/** Outcome of a single sync item attempt. */
+sealed class SyncItemResult {
+    object Success : SyncItemResult()
+    data class Retry(val reason: String) : SyncItemResult()
+    data class Expired(val reason: String) : SyncItemResult()
+    data class Failed(val reason: String) : SyncItemResult()
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/sync/SyncQueueRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/sync/SyncQueueRepository.kt
@@ -1,0 +1,46 @@
+package id.cachet.wallet.domain.sync
+
+/**
+ * Repository interface for sync queue persistence.
+ * Abstracts SQLDelight queries for testability.
+ */
+interface SyncQueueRepository {
+
+    // ── Anchoring queue ──
+
+    data class PendingAnchoringItem(
+        val receiptId: String,
+        val retryCount: Long,
+        val status: String
+    )
+
+    suspend fun getPendingAnchorings(): List<PendingAnchoringItem>
+    suspend fun deletePendingAnchoring(receiptId: String)
+    suspend fun updatePendingAnchoringStatus(receiptId: String, status: String, retryCount: Long, lastAttemptAt: Long)
+
+    // ── Issuance queue ──
+
+    data class PendingIssuanceItem(
+        val id: String,
+        val clientId: String,
+        val credentialTypesJson: String,
+        val format: String,
+        val sessionId: String?,
+        val accessToken: String,
+        val tokenExpiresAt: Long,
+        val keyAlias: String?,
+        val holderJwk: String?,
+        val retryCount: Long,
+        val status: String
+    )
+
+    suspend fun deleteExpiredIssuances(nowMillis: Long)
+    suspend fun getPendingIssuances(): List<PendingIssuanceItem>
+    suspend fun deletePendingIssuance(id: String)
+    suspend fun updatePendingIssuanceStatus(id: String, status: String, retryCount: Long, lastAttemptAt: Long)
+
+    // ── Counts ──
+
+    suspend fun getPendingAnchoringCount(): Int
+    suspend fun getPendingIssuanceCount(): Int
+}

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/usecase/ConsentUseCase.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/usecase/ConsentUseCase.kt
@@ -4,6 +4,7 @@ import id.cachet.wallet.domain.model.*
 import id.cachet.wallet.domain.repository.CredentialRepository
 import id.cachet.wallet.domain.repository.ConsentReceiptRepository
 import id.cachet.wallet.domain.repository.TransparencyLogRepository
+import id.cachet.wallet.domain.sync.AnchoringQueue
 import kotlin.time.Clock
 
 /**
@@ -12,7 +13,8 @@ import kotlin.time.Clock
 class ConsentUseCase(
     private val credentialRepository: CredentialRepository,
     private val consentReceiptRepository: ConsentReceiptRepository,
-    private val transparencyLogRepository: TransparencyLogRepository
+    private val transparencyLogRepository: TransparencyLogRepository,
+    private val anchoringQueue: AnchoringQueue? = null
 ) {
     
     /**
@@ -249,7 +251,8 @@ class ConsentUseCase(
                 jurisdiction = extractJurisdiction(receipt.rpIdentifier)
             )
             
-            val response = transparencyLogRepository.submitReceiptHash(request).getOrElse { 
+            val response = transparencyLogRepository.submitReceiptHash(request).getOrElse {
+                anchoringQueue?.enqueue(receipt.id)
                 return Result.success(receipt) // Continue without transparency log if it fails
             }
             
@@ -265,7 +268,8 @@ class ConsentUseCase(
             Result.success(receiptWithLog)
             
         } catch (e: Exception) {
-            // Graceful degradation - continue without transparency log
+            // Graceful degradation - enqueue for later and continue without transparency log
+            anchoringQueue?.enqueue(receipt.id)
             Result.success(receipt)
         }
     }

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/usecase/IssuanceUseCase.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/domain/usecase/IssuanceUseCase.kt
@@ -3,6 +3,8 @@ package id.cachet.wallet.domain.usecase
 import id.cachet.wallet.domain.crypto.KeyManager
 import id.cachet.wallet.domain.model.StoredCredential
 import id.cachet.wallet.domain.repository.CredentialRepository
+import id.cachet.wallet.domain.sync.IssuanceQueue
+import id.cachet.wallet.domain.sync.PendingIssuanceState
 import id.cachet.wallet.network.OpenID4VCIClient
 import kotlin.time.Clock
 import kotlin.random.Random
@@ -10,7 +12,8 @@ import kotlin.random.Random
 class IssuanceUseCase(
     private val credentialRepository: CredentialRepository,
     private val openID4VCIClient: OpenID4VCIClient,
-    private val keyManager: KeyManager? = null
+    private val keyManager: KeyManager? = null,
+    private val issuanceQueue: IssuanceQueue? = null
 ) {
     
     private fun generateUuid(): String {
@@ -32,28 +35,45 @@ class IssuanceUseCase(
                 scope = "credential_issuance",
                 sessionId = sessionId
             )
-            
+
             // Step 2: Request credential using the token
-            val credentialResponse = openID4VCIClient.requestCredential(
-                accessToken = tokenResponse.accessToken,
-                format = format,
-                types = credentialTypes
-            )
-            
-            // Step 3: Create stored credential with local ID
-            val storedCredential = StoredCredential(
-                localId = generateUuid(),
-                credential = credentialResponse.credential,
-                rawJwt = null, // TODO: Extract JWT from response if format is jwt_vc
-                createdAt = Clock.System.now(),
-                isRevoked = false
-            )
-            
-            // Step 4: Store credential in local repository
-            credentialRepository.storeCredential(storedCredential)
-            
-            Result.success(storedCredential)
+            // If this fails, persist partial state for retry on reconnect
+            try {
+                val credentialResponse = openID4VCIClient.requestCredential(
+                    accessToken = tokenResponse.accessToken,
+                    format = format,
+                    types = credentialTypes
+                )
+
+                val storedCredential = StoredCredential(
+                    localId = generateUuid(),
+                    credential = credentialResponse.credential,
+                    rawJwt = null,
+                    createdAt = Clock.System.now(),
+                    isRevoked = false
+                )
+
+                credentialRepository.storeCredential(storedCredential)
+                Result.success(storedCredential)
+            } catch (e: Exception) {
+                val expiresAt = Clock.System.now().toEpochMilliseconds() + (tokenResponse.expiresIn * 1000L)
+                issuanceQueue?.enqueue(
+                    PendingIssuanceState(
+                        id = generateUuid(),
+                        clientId = clientId,
+                        credentialTypes = credentialTypes,
+                        format = format,
+                        sessionId = sessionId,
+                        accessToken = tokenResponse.accessToken,
+                        tokenExpiresAt = expiresAt,
+                        keyAlias = null,
+                        holderJwk = null
+                    )
+                )
+                Result.failure(IssuanceException("Credential fetch failed, queued for retry: ${e.message}", e))
+            }
         } catch (e: Exception) {
+            // Token request itself failed — nothing to queue
             Result.failure(IssuanceException("Failed to issue credential: ${e.message}", e))
         }
     }
@@ -83,49 +103,65 @@ class IssuanceUseCase(
                 sessionId = sessionId
             )
 
-            // Step 2.5: Fetch c_nonce for proof replay prevention (T15)
-            val cNonce = try {
-                openID4VCIClient.requestNonce().cNonce
-            } catch (_: Exception) {
-                null // graceful fallback if issuer doesn't support nonce yet
-            }
+            // Step 3: Fetch credential — if this fails, persist partial state for retry
+            try {
+                // Fetch c_nonce for proof replay prevention (T15)
+                val cNonce = try {
+                    openID4VCIClient.requestNonce().cNonce
+                } catch (_: Exception) {
+                    null // graceful fallback if issuer doesn't support nonce yet
+                }
 
-            // Step 3: Build proof JWT and request SD-JWT credential
-            val proofJWT = if (cNonce != null) {
-                id.cachet.wallet.domain.crypto.KBJWTBuilder.buildProofJWT(
-                    nonce = cNonce,
-                    audience = id.cachet.wallet.config.AppConfig.baseUrl,
-                    keyManager = km,
-                    keyAlias = keyAlias
+                val proofJWT = if (cNonce != null) {
+                    id.cachet.wallet.domain.crypto.KBJWTBuilder.buildProofJWT(
+                        nonce = cNonce,
+                        audience = id.cachet.wallet.config.AppConfig.baseUrl,
+                        keyManager = km,
+                        keyAlias = keyAlias
+                    )
+                } else null
+
+                val credentialResponse = openID4VCIClient.requestSDJWTCredential(
+                    accessToken = tokenResponse.accessToken,
+                    types = credentialTypes,
+                    holderJWK = holderJWK,
+                    proofJWT = proofJWT
                 )
-            } else null
 
-            val credentialResponse = openID4VCIClient.requestSDJWTCredential(
-                accessToken = tokenResponse.accessToken,
-                types = credentialTypes,
-                holderJWK = holderJWK,
-                proofJWT = proofJWT
-            )
+                val parsed = id.cachet.wallet.domain.crypto.SDJWTParser.parse(credentialResponse.credential)
+                val displayCredential = buildDisplayCredentialFromSDJWT(parsed, credentialTypes)
 
-            // Step 4: Parse SD-JWT to extract display data
-            val parsed = id.cachet.wallet.domain.crypto.SDJWTParser.parse(credentialResponse.credential)
+                val storedCredential = StoredCredential(
+                    localId = generateUuid(),
+                    credential = displayCredential,
+                    rawSdJwt = credentialResponse.credential,
+                    keyAlias = keyAlias,
+                    createdAt = Clock.System.now(),
+                    isRevoked = false
+                )
 
-            // Step 5: Build a minimal VerifiableCredential for display
-            // The real credential is the raw SD-JWT string
-            val displayCredential = buildDisplayCredentialFromSDJWT(parsed, credentialTypes)
-
-            val storedCredential = StoredCredential(
-                localId = generateUuid(),
-                credential = displayCredential,
-                rawSdJwt = credentialResponse.credential,
-                keyAlias = keyAlias,
-                createdAt = Clock.System.now(),
-                isRevoked = false
-            )
-
-            credentialRepository.storeCredential(storedCredential)
-            Result.success(storedCredential)
+                credentialRepository.storeCredential(storedCredential)
+                Result.success(storedCredential)
+            } catch (e: Exception) {
+                // Credential fetch failed after token was obtained — persist for retry
+                val expiresAt = Clock.System.now().toEpochMilliseconds() + (tokenResponse.expiresIn * 1000L)
+                issuanceQueue?.enqueue(
+                    PendingIssuanceState(
+                        id = generateUuid(),
+                        clientId = clientId,
+                        credentialTypes = credentialTypes,
+                        format = "vc+sd-jwt",
+                        sessionId = sessionId,
+                        accessToken = tokenResponse.accessToken,
+                        tokenExpiresAt = expiresAt,
+                        keyAlias = keyAlias,
+                        holderJwk = holderJWK
+                    )
+                )
+                Result.failure(IssuanceException("Credential fetch failed, queued for retry: ${e.message}", e))
+            }
         } catch (e: Exception) {
+            // Token request itself failed — nothing to queue
             Result.failure(IssuanceException("Failed to issue SD-JWT credential: ${e.message}", e))
         }
     }

--- a/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/shared/di/SharedModule.kt
+++ b/mobile/shared/src/commonMain/kotlin/id/cachet/wallet/shared/di/SharedModule.kt
@@ -22,6 +22,14 @@ import id.cachet.wallet.domain.usecase.IssuanceUseCase
 import id.cachet.wallet.domain.usecase.ConsentUseCase
 import id.cachet.wallet.domain.usecase.VerificationUseCase
 import id.cachet.wallet.domain.crypto.EphemeralKeyGenerator
+import id.cachet.wallet.domain.sync.AnchoringQueue
+import id.cachet.wallet.domain.sync.ConnectivityObserver
+import id.cachet.wallet.domain.sync.IssuanceQueue
+import id.cachet.wallet.domain.sync.SqlDelightAnchoringQueue
+import id.cachet.wallet.domain.sync.SqlDelightIssuanceQueue
+import id.cachet.wallet.domain.sync.SqlDelightSyncQueueRepository
+import id.cachet.wallet.domain.sync.SyncManager
+import id.cachet.wallet.domain.sync.SyncQueueRepository
 import id.cachet.wallet.domain.transport.LocalSessionManager
 import id.cachet.wallet.domain.transport.QrDirectTransport
 import id.cachet.wallet.config.AppConfig
@@ -127,12 +135,31 @@ val sharedModule = module {
         )
     }
 
+    // Offline sync queues
+    single<AnchoringQueue> { SqlDelightAnchoringQueue(database = get<WalletDatabase>()) }
+    single<IssuanceQueue> { SqlDelightIssuanceQueue(database = get<WalletDatabase>()) }
+    single<SyncQueueRepository> { SqlDelightSyncQueueRepository(database = get<WalletDatabase>()) }
+
+    // SyncManager — ConnectivityObserver is provided by the platform-specific module
+    single {
+        SyncManager(
+            connectivity = get(),
+            queueRepository = get(),
+            consentReceiptRepository = get(),
+            transparencyLogRepository = get(),
+            openID4VCIClient = get(),
+            credentialRepository = get(),
+            keyManager = get()
+        )
+    }
+
     // Use cases
     single {
         IssuanceUseCase(
             credentialRepository = get(),
             openID4VCIClient = get(),
-            keyManager = get()
+            keyManager = get(),
+            issuanceQueue = get()
         )
     }
 
@@ -140,7 +167,8 @@ val sharedModule = module {
         ConsentUseCase(
             credentialRepository = get(),
             consentReceiptRepository = get(),
-            transparencyLogRepository = get()
+            transparencyLogRepository = get(),
+            anchoringQueue = get()
         )
     }
 

--- a/mobile/shared/src/commonMain/sqldelight/id/cachet/wallet/db/WalletDatabase.sq
+++ b/mobile/shared/src/commonMain/sqldelight/id/cachet/wallet/db/WalletDatabase.sq
@@ -145,3 +145,68 @@ DELETE FROM cached_status_lists WHERE status_list_url = ?;
 
 deleteExpiredStatusLists:
 DELETE FROM cached_status_lists WHERE fetched_at < ?;
+
+-- Offline sync: pending anchoring queue
+CREATE TABLE pending_anchoring (
+    receipt_id TEXT PRIMARY KEY NOT NULL,
+    created_at INTEGER NOT NULL,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    last_attempt_at INTEGER,
+    status TEXT NOT NULL DEFAULT 'pending'
+);
+
+CREATE INDEX idx_pending_anchoring_status ON pending_anchoring(status);
+
+insertPendingAnchoring:
+INSERT OR IGNORE INTO pending_anchoring (receipt_id, created_at, retry_count, last_attempt_at, status)
+VALUES (?, ?, ?, ?, ?);
+
+getPendingAnchorings:
+SELECT * FROM pending_anchoring WHERE status = 'pending'
+ORDER BY created_at ASC;
+
+updatePendingAnchoringStatus:
+UPDATE pending_anchoring SET status = ?, retry_count = ?, last_attempt_at = ? WHERE receipt_id = ?;
+
+deletePendingAnchoring:
+DELETE FROM pending_anchoring WHERE receipt_id = ?;
+
+-- Update consent receipt transparency log (for async anchoring)
+updateReceiptTransparencyLog:
+UPDATE consent_receipts SET transparency_log_json = ? WHERE id = ?;
+
+-- Offline sync: pending issuance queue
+CREATE TABLE pending_issuance (
+    id TEXT PRIMARY KEY NOT NULL,
+    client_id TEXT NOT NULL,
+    credential_types_json TEXT NOT NULL,
+    format TEXT NOT NULL,
+    session_id TEXT,
+    access_token TEXT NOT NULL,
+    token_expires_at INTEGER NOT NULL,
+    key_alias TEXT,
+    holder_jwk TEXT,
+    created_at INTEGER NOT NULL,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    last_attempt_at INTEGER,
+    status TEXT NOT NULL DEFAULT 'pending'
+);
+
+CREATE INDEX idx_pending_issuance_status ON pending_issuance(status);
+
+insertPendingIssuance:
+INSERT OR REPLACE INTO pending_issuance (id, client_id, credential_types_json, format, session_id, access_token, token_expires_at, key_alias, holder_jwk, created_at, retry_count, last_attempt_at, status)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+getPendingIssuances:
+SELECT * FROM pending_issuance WHERE status = 'pending'
+ORDER BY created_at ASC;
+
+updatePendingIssuanceStatus:
+UPDATE pending_issuance SET status = ?, retry_count = ?, last_attempt_at = ? WHERE id = ?;
+
+deletePendingIssuance:
+DELETE FROM pending_issuance WHERE id = ?;
+
+deleteExpiredIssuances:
+DELETE FROM pending_issuance WHERE token_expires_at < ?;

--- a/mobile/shared/src/commonMain/sqldelight/migrations/4.sqm
+++ b/mobile/shared/src/commonMain/sqldelight/migrations/4.sqm
@@ -1,0 +1,31 @@
+-- Migration from version 4 to 5: add offline sync queue tables
+
+-- Queue for consent receipts that need transparency log anchoring
+CREATE TABLE pending_anchoring (
+    receipt_id TEXT PRIMARY KEY NOT NULL,
+    created_at INTEGER NOT NULL,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    last_attempt_at INTEGER,
+    status TEXT NOT NULL DEFAULT 'pending'
+);
+
+CREATE INDEX idx_pending_anchoring_status ON pending_anchoring(status);
+
+-- Queue for partially-completed issuance flows
+CREATE TABLE pending_issuance (
+    id TEXT PRIMARY KEY NOT NULL,
+    client_id TEXT NOT NULL,
+    credential_types_json TEXT NOT NULL,
+    format TEXT NOT NULL,
+    session_id TEXT,
+    access_token TEXT NOT NULL,
+    token_expires_at INTEGER NOT NULL,
+    key_alias TEXT,
+    holder_jwk TEXT,
+    created_at INTEGER NOT NULL,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    last_attempt_at INTEGER,
+    status TEXT NOT NULL DEFAULT 'pending'
+);
+
+CREATE INDEX idx_pending_issuance_status ON pending_issuance(status);

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/sync/SyncManagerTest.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/sync/SyncManagerTest.kt
@@ -1,0 +1,294 @@
+package id.cachet.wallet.domain.sync
+
+import id.cachet.wallet.domain.model.*
+import id.cachet.wallet.domain.repository.InMemoryConsentReceiptRepository
+import id.cachet.wallet.domain.repository.MockTransparencyLogRepository
+import id.cachet.wallet.domain.repository.TransparencyLogRepository
+import id.cachet.wallet.network.CredentialResponse
+import id.cachet.wallet.testfixtures.FakeConnectivityObserver
+import id.cachet.wallet.testfixtures.FakeCredentialRepository
+import id.cachet.wallet.testfixtures.FakeOpenID4VCIClient
+import id.cachet.wallet.testfixtures.FakeSyncQueueRepository
+import id.cachet.wallet.testfixtures.makeCredential
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Clock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SyncManagerTest {
+
+    /** Transparency log that always fails. */
+    private class FailingLogRepository : TransparencyLogRepository {
+        override suspend fun submitReceiptHash(request: AddEntryRequest) =
+            Result.failure<AddEntryResponse>(RuntimeException("Network error"))
+        override suspend fun getCurrentSTH() =
+            Result.failure<SignedTreeHead>(RuntimeException("Network error"))
+        override suspend fun getEntries(start: Long, end: Long) =
+            Result.failure<List<LogEntry>>(RuntimeException("Network error"))
+        override suspend fun getInclusionProof(leafIndex: Long, treeSize: Long) =
+            Result.failure<InclusionProof>(RuntimeException("Network error"))
+        override suspend fun getConsistencyProof(firstTreeSize: Long, secondTreeSize: Long) =
+            Result.failure<ConsistencyProof>(RuntimeException("Network error"))
+        override fun verifyInclusionProof(leafHash: String, proof: InclusionProof) = false
+        override fun verifyConsistencyProof(firstSTH: SignedTreeHead, secondSTH: SignedTreeHead, proof: ConsistencyProof) = false
+    }
+
+    private fun makeReceipt(id: String, anchored: Boolean = false) = ConsentReceipt(
+        id = id,
+        timestamp = Clock.System.now(),
+        purpose = "Test verification purpose",
+        predicatesProven = listOf("age_gte_18"),
+        rpIdentifier = "did:web:test.com",
+        rpDisplayName = "Test Verifier",
+        userConsent = ConsentDetails(
+            explicitConsent = true,
+            dataMinimizationAcknowledged = true,
+            retentionPeriodUnderstood = true
+        ),
+        credentialId = "cred-1",
+        receiptHash = "abc123hash",
+        salt = "test-salt",
+        signature = "test-sig",
+        transparencyLogEntry = if (anchored) TransparencyLogEntry(logId = "log", logIndex = 42) else null
+    )
+
+    @Test
+    fun `pendingCount starts at zero`() = runTest {
+        val manager = SyncManager(
+            connectivity = FakeConnectivityObserver(),
+            queueRepository = FakeSyncQueueRepository(),
+            consentReceiptRepository = InMemoryConsentReceiptRepository(),
+            transparencyLogRepository = MockTransparencyLogRepository(),
+            openID4VCIClient = FakeOpenID4VCIClient(),
+            credentialRepository = FakeCredentialRepository(),
+            scope = this
+        )
+
+        assertEquals(0, manager.pendingCount.value)
+    }
+
+    @Test
+    fun `pendingCount reflects enqueued items`() = runTest {
+        val queueRepo = FakeSyncQueueRepository()
+        queueRepo.anchoringItems.add(
+            SyncQueueRepository.PendingAnchoringItem("receipt-1", 0, "pending")
+        )
+
+        val manager = SyncManager(
+            connectivity = FakeConnectivityObserver(),
+            queueRepository = queueRepo,
+            consentReceiptRepository = InMemoryConsentReceiptRepository(),
+            transparencyLogRepository = MockTransparencyLogRepository(),
+            openID4VCIClient = FakeOpenID4VCIClient(),
+            credentialRepository = FakeCredentialRepository(),
+            scope = this
+        )
+
+        manager.refreshPendingCount()
+        assertEquals(1, manager.pendingCount.value)
+    }
+
+    @Test
+    fun `drains anchoring queue on connectivity restore`() = runTest {
+        val queueRepo = FakeSyncQueueRepository()
+        val consentRepo = InMemoryConsentReceiptRepository()
+        val connectivity = FakeConnectivityObserver(initialOnline = false)
+
+        consentRepo.storeReceipt(makeReceipt("receipt-1"))
+        queueRepo.anchoringItems.add(
+            SyncQueueRepository.PendingAnchoringItem("receipt-1", 0, "pending")
+        )
+
+        val manager = SyncManager(
+            connectivity = connectivity,
+            queueRepository = queueRepo,
+            consentReceiptRepository = consentRepo,
+            transparencyLogRepository = MockTransparencyLogRepository(),
+            openID4VCIClient = FakeOpenID4VCIClient(),
+            credentialRepository = FakeCredentialRepository(),
+            scope = this
+        )
+
+        manager.start()
+        advanceUntilIdle()
+
+        // Still pending (offline)
+        manager.refreshPendingCount()
+        assertEquals(1, manager.pendingCount.value)
+
+        // Go online → triggers drain
+        connectivity.goOnline()
+        advanceUntilIdle()
+
+        // Queue should be drained
+        manager.refreshPendingCount()
+        assertEquals(0, manager.pendingCount.value)
+    }
+
+    @Test
+    fun `skips already-anchored receipts as idempotent`() = runTest {
+        val queueRepo = FakeSyncQueueRepository()
+        val consentRepo = InMemoryConsentReceiptRepository()
+
+        consentRepo.storeReceipt(makeReceipt("receipt-already", anchored = true))
+        queueRepo.anchoringItems.add(
+            SyncQueueRepository.PendingAnchoringItem("receipt-already", 0, "pending")
+        )
+
+        val manager = SyncManager(
+            connectivity = FakeConnectivityObserver(initialOnline = true),
+            queueRepository = queueRepo,
+            consentReceiptRepository = consentRepo,
+            transparencyLogRepository = MockTransparencyLogRepository(),
+            openID4VCIClient = FakeOpenID4VCIClient(),
+            credentialRepository = FakeCredentialRepository(),
+            scope = this
+        )
+
+        manager.triggerSync()
+        advanceUntilIdle()
+
+        manager.refreshPendingCount()
+        assertEquals(0, manager.pendingCount.value)
+    }
+
+    @Test
+    fun `marks anchoring as failed after max retries`() = runTest {
+        val queueRepo = FakeSyncQueueRepository()
+        val consentRepo = InMemoryConsentReceiptRepository()
+
+        consentRepo.storeReceipt(makeReceipt("receipt-retry"))
+        queueRepo.anchoringItems.add(
+            SyncQueueRepository.PendingAnchoringItem(
+                "receipt-retry",
+                (SyncManager.MAX_RETRY_COUNT - 1).toLong(),
+                "pending"
+            )
+        )
+
+        val manager = SyncManager(
+            connectivity = FakeConnectivityObserver(initialOnline = true),
+            queueRepository = queueRepo,
+            consentReceiptRepository = consentRepo,
+            transparencyLogRepository = FailingLogRepository(),
+            openID4VCIClient = FakeOpenID4VCIClient(),
+            credentialRepository = FakeCredentialRepository(),
+            scope = this
+        )
+
+        manager.triggerSync()
+        advanceUntilIdle()
+
+        assertEquals(1, queueRepo.anchoringItems.size)
+        assertEquals("failed", queueRepo.anchoringItems[0].status)
+        assertEquals(SyncManager.MAX_RETRY_COUNT.toLong(), queueRepo.anchoringItems[0].retryCount)
+    }
+
+    @Test
+    fun `marks issuance as expired when token is past expiry`() = runTest {
+        val queueRepo = FakeSyncQueueRepository()
+        val expiredAt = Clock.System.now().toEpochMilliseconds() - 3_600_000L
+
+        queueRepo.issuanceItems.add(
+            SyncQueueRepository.PendingIssuanceItem(
+                id = "issuance-expired",
+                clientId = "test",
+                credentialTypesJson = """["VerifiableCredential"]""",
+                format = "jwt_vc",
+                sessionId = null,
+                accessToken = "expired-token",
+                tokenExpiresAt = expiredAt,
+                keyAlias = null,
+                holderJwk = null,
+                retryCount = 0,
+                status = "pending"
+            )
+        )
+
+        val manager = SyncManager(
+            connectivity = FakeConnectivityObserver(initialOnline = true),
+            queueRepository = queueRepo,
+            consentReceiptRepository = InMemoryConsentReceiptRepository(),
+            transparencyLogRepository = MockTransparencyLogRepository(),
+            openID4VCIClient = FakeOpenID4VCIClient(),
+            credentialRepository = FakeCredentialRepository(),
+            scope = this
+        )
+
+        manager.triggerSync()
+        advanceUntilIdle()
+
+        // Expired items get deleted by deleteExpiredIssuances
+        manager.refreshPendingCount()
+        assertEquals(0, manager.pendingCount.value)
+    }
+
+    @Test
+    fun `resumes issuance with valid token`() = runTest {
+        val queueRepo = FakeSyncQueueRepository()
+        val credentialRepo = FakeCredentialRepository()
+        val client = FakeOpenID4VCIClient(
+            credentialResponse = CredentialResponse(
+                credential = makeCredential(),
+                format = "jwt_vc"
+            )
+        )
+
+        val expiresAt = Clock.System.now().toEpochMilliseconds() + 3_600_000L
+        queueRepo.issuanceItems.add(
+            SyncQueueRepository.PendingIssuanceItem(
+                id = "issuance-valid",
+                clientId = "test",
+                credentialTypesJson = """["VerifiableCredential"]""",
+                format = "jwt_vc",
+                sessionId = null,
+                accessToken = "valid-token",
+                tokenExpiresAt = expiresAt,
+                keyAlias = null,
+                holderJwk = null,
+                retryCount = 0,
+                status = "pending"
+            )
+        )
+
+        val manager = SyncManager(
+            connectivity = FakeConnectivityObserver(initialOnline = true),
+            queueRepository = queueRepo,
+            consentReceiptRepository = InMemoryConsentReceiptRepository(),
+            transparencyLogRepository = MockTransparencyLogRepository(),
+            openID4VCIClient = client,
+            credentialRepository = credentialRepo,
+            scope = this
+        )
+
+        manager.triggerSync()
+        advanceUntilIdle()
+
+        manager.refreshPendingCount()
+        assertEquals(0, manager.pendingCount.value)
+        assertEquals(1, credentialRepo.getAllCredentials().size)
+    }
+
+    @Test
+    fun `syncStatus transitions correctly`() = runTest {
+        val manager = SyncManager(
+            connectivity = FakeConnectivityObserver(initialOnline = true),
+            queueRepository = FakeSyncQueueRepository(),
+            consentReceiptRepository = InMemoryConsentReceiptRepository(),
+            transparencyLogRepository = MockTransparencyLogRepository(),
+            openID4VCIClient = FakeOpenID4VCIClient(),
+            credentialRepository = FakeCredentialRepository(),
+            scope = this
+        )
+
+        assertEquals(SyncStatus.IDLE, manager.syncStatus.value)
+
+        manager.triggerSync()
+        advanceUntilIdle()
+
+        assertEquals(SyncStatus.IDLE, manager.syncStatus.value)
+    }
+}

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/usecase/ConsentUseCaseOfflineTest.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/usecase/ConsentUseCaseOfflineTest.kt
@@ -1,0 +1,92 @@
+package id.cachet.wallet.domain.usecase
+
+import id.cachet.wallet.domain.model.*
+import id.cachet.wallet.domain.repository.InMemoryConsentReceiptRepository
+import id.cachet.wallet.domain.repository.MockTransparencyLogRepository
+import id.cachet.wallet.domain.repository.TransparencyLogRepository
+import id.cachet.wallet.testfixtures.FakeAnchoringQueue
+import id.cachet.wallet.testfixtures.FakeCredentialRepository
+import id.cachet.wallet.testfixtures.makeCredential
+import id.cachet.wallet.testfixtures.makePresentationRequest
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ConsentUseCaseOfflineTest {
+
+    private val validConsent = ConsentDetails(
+        explicitConsent = true,
+        dataMinimizationAcknowledged = true,
+        retentionPeriodUnderstood = true,
+        retentionPeriodDays = 90
+    )
+
+    /** Transparency log that always fails on submitReceiptHash. */
+    private class FailingTransparencyLogRepository : TransparencyLogRepository {
+        override suspend fun submitReceiptHash(request: AddEntryRequest): Result<AddEntryResponse> =
+            Result.failure(RuntimeException("Network unavailable"))
+
+        override suspend fun getCurrentSTH(): Result<SignedTreeHead> =
+            Result.failure(RuntimeException("Network unavailable"))
+
+        override suspend fun getEntries(start: Long, end: Long): Result<List<LogEntry>> =
+            Result.failure(RuntimeException("Network unavailable"))
+
+        override suspend fun getInclusionProof(leafIndex: Long, treeSize: Long): Result<InclusionProof> =
+            Result.failure(RuntimeException("Network unavailable"))
+
+        override suspend fun getConsistencyProof(firstTreeSize: Long, secondTreeSize: Long): Result<ConsistencyProof> =
+            Result.failure(RuntimeException("Network unavailable"))
+
+        override fun verifyInclusionProof(leafHash: String, proof: InclusionProof): Boolean = false
+        override fun verifyConsistencyProof(firstSTH: SignedTreeHead, secondSTH: SignedTreeHead, proof: ConsistencyProof): Boolean = false
+    }
+
+    @Test
+    fun `generateConsentReceipt enqueues when transparency log fails`() = runTest {
+        val queue = FakeAnchoringQueue()
+        val useCase = ConsentUseCase(
+            credentialRepository = FakeCredentialRepository(),
+            consentReceiptRepository = InMemoryConsentReceiptRepository(),
+            transparencyLogRepository = FailingTransparencyLogRepository(),
+            anchoringQueue = queue
+        )
+
+        val result = useCase.generateConsentReceipt(makeCredential(), makePresentationRequest(), validConsent)
+
+        assertTrue(result.isSuccess, "Receipt should still succeed even when anchoring fails")
+        assertEquals(1, queue.enqueuedReceiptIds.size, "Receipt should be enqueued for later anchoring")
+        assertEquals(result.getOrThrow().id, queue.enqueuedReceiptIds[0])
+    }
+
+    @Test
+    fun `generateConsentReceipt does not enqueue when transparency log succeeds`() = runTest {
+        val queue = FakeAnchoringQueue()
+        val useCase = ConsentUseCase(
+            credentialRepository = FakeCredentialRepository(),
+            consentReceiptRepository = InMemoryConsentReceiptRepository(),
+            transparencyLogRepository = MockTransparencyLogRepository(),
+            anchoringQueue = queue
+        )
+
+        val result = useCase.generateConsentReceipt(makeCredential(), makePresentationRequest(), validConsent)
+
+        assertTrue(result.isSuccess)
+        assertEquals(0, queue.enqueuedReceiptIds.size, "No enqueue needed when anchoring succeeds")
+    }
+
+    @Test
+    fun `generateConsentReceipt does not crash when no queue configured`() = runTest {
+        val useCase = ConsentUseCase(
+            credentialRepository = FakeCredentialRepository(),
+            consentReceiptRepository = InMemoryConsentReceiptRepository(),
+            transparencyLogRepository = FailingTransparencyLogRepository(),
+            anchoringQueue = null
+        )
+
+        val result = useCase.generateConsentReceipt(makeCredential(), makePresentationRequest(), validConsent)
+
+        assertTrue(result.isSuccess, "Should succeed even without queue (backward compat)")
+    }
+}

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/usecase/IssuanceUseCaseOfflineTest.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/domain/usecase/IssuanceUseCaseOfflineTest.kt
@@ -1,0 +1,160 @@
+package id.cachet.wallet.domain.usecase
+
+import id.cachet.wallet.network.CredentialResponse
+import id.cachet.wallet.testfixtures.FakeCredentialRepository
+import id.cachet.wallet.testfixtures.FakeIssuanceQueue
+import id.cachet.wallet.testfixtures.FakeKeyManager
+import id.cachet.wallet.testfixtures.FakeOpenID4VCIClient
+import id.cachet.wallet.testfixtures.makeCredential
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class IssuanceUseCaseOfflineTest {
+
+    @Test
+    fun `requestCredential enqueues when credential fetch fails after token success`() = runTest {
+        val queue = FakeIssuanceQueue()
+        val client = FakeOpenID4VCIClient(
+            credentialError = RuntimeException("Network unavailable")
+        )
+        val useCase = IssuanceUseCase(
+            credentialRepository = FakeCredentialRepository(),
+            openID4VCIClient = client,
+            issuanceQueue = queue
+        )
+
+        val result = useCase.requestCredential(
+            clientId = "test-client",
+            credentialTypes = listOf("VerifiableCredential"),
+            sessionId = "session-1"
+        )
+
+        assertTrue(result.isFailure, "Should fail when credential fetch fails")
+        assertEquals(1, queue.enqueuedStates.size, "Should enqueue partial state")
+        val state = queue.enqueuedStates[0]
+        assertEquals("test-client", state.clientId)
+        assertEquals(listOf("VerifiableCredential"), state.credentialTypes)
+        assertEquals("jwt_vc", state.format)
+        assertEquals("session-1", state.sessionId)
+        assertEquals("fake-token", state.accessToken)
+        assertTrue(state.tokenExpiresAt > 0, "Should have valid expiry")
+    }
+
+    @Test
+    fun `requestCredential does not enqueue when token request fails`() = runTest {
+        val queue = FakeIssuanceQueue()
+        val client = FakeOpenID4VCIClient(
+            tokenError = RuntimeException("Token server unreachable")
+        )
+        val useCase = IssuanceUseCase(
+            credentialRepository = FakeCredentialRepository(),
+            openID4VCIClient = client,
+            issuanceQueue = queue
+        )
+
+        val result = useCase.requestCredential(
+            clientId = "test-client",
+            credentialTypes = listOf("VerifiableCredential")
+        )
+
+        assertTrue(result.isFailure, "Should fail when token request fails")
+        assertEquals(0, queue.enqueuedStates.size, "Should NOT enqueue when token failed")
+    }
+
+    @Test
+    fun `requestCredential does not crash when no queue configured`() = runTest {
+        val client = FakeOpenID4VCIClient(
+            credentialError = RuntimeException("Network unavailable")
+        )
+        val useCase = IssuanceUseCase(
+            credentialRepository = FakeCredentialRepository(),
+            openID4VCIClient = client,
+            issuanceQueue = null
+        )
+
+        val result = useCase.requestCredential(
+            clientId = "test-client",
+            credentialTypes = listOf("VerifiableCredential")
+        )
+
+        assertTrue(result.isFailure, "Should fail gracefully without queue")
+    }
+
+    @Test
+    fun `requestSDJWTCredential enqueues when credential fetch fails after token success`() = runTest {
+        val queue = FakeIssuanceQueue()
+        val client = FakeOpenID4VCIClient(
+            sdJwtCredentialError = RuntimeException("Network unavailable")
+        )
+        val useCase = IssuanceUseCase(
+            credentialRepository = FakeCredentialRepository(),
+            openID4VCIClient = client,
+            keyManager = FakeKeyManager(),
+            issuanceQueue = queue
+        )
+
+        val result = useCase.requestSDJWTCredential(
+            clientId = "test-client",
+            credentialTypes = listOf("VerifiableCredential", "IdentityCredential"),
+            sessionId = "session-2"
+        )
+
+        assertTrue(result.isFailure, "Should fail when SD-JWT credential fetch fails")
+        assertEquals(1, queue.enqueuedStates.size, "Should enqueue partial state")
+        val state = queue.enqueuedStates[0]
+        assertEquals("test-client", state.clientId)
+        assertEquals("vc+sd-jwt", state.format)
+        assertEquals("session-2", state.sessionId)
+        assertEquals("fake-token", state.accessToken)
+        assertTrue(state.keyAlias != null, "Should preserve key alias")
+        assertTrue(state.holderJwk != null, "Should preserve holder JWK")
+    }
+
+    @Test
+    fun `requestSDJWTCredential does not enqueue when token request fails`() = runTest {
+        val queue = FakeIssuanceQueue()
+        val client = FakeOpenID4VCIClient(
+            tokenError = RuntimeException("Token server unreachable")
+        )
+        val useCase = IssuanceUseCase(
+            credentialRepository = FakeCredentialRepository(),
+            openID4VCIClient = client,
+            keyManager = FakeKeyManager(),
+            issuanceQueue = queue
+        )
+
+        val result = useCase.requestSDJWTCredential(
+            clientId = "test-client",
+            credentialTypes = listOf("VerifiableCredential")
+        )
+
+        assertTrue(result.isFailure, "Should fail when token request fails")
+        assertEquals(0, queue.enqueuedStates.size, "Should NOT enqueue when token failed")
+    }
+
+    @Test
+    fun `requestCredential succeeds normally without enqueuing`() = runTest {
+        val queue = FakeIssuanceQueue()
+        val client = FakeOpenID4VCIClient(
+            credentialResponse = CredentialResponse(
+                credential = makeCredential(),
+                format = "jwt_vc"
+            )
+        )
+        val useCase = IssuanceUseCase(
+            credentialRepository = FakeCredentialRepository(),
+            openID4VCIClient = client,
+            issuanceQueue = queue
+        )
+
+        val result = useCase.requestCredential(
+            clientId = "test-client",
+            credentialTypes = listOf("VerifiableCredential")
+        )
+
+        assertTrue(result.isSuccess, "Should succeed normally")
+        assertEquals(0, queue.enqueuedStates.size, "Should NOT enqueue on success")
+    }
+}

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/integration/SyncIntegrationTest.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/integration/SyncIntegrationTest.kt
@@ -1,0 +1,318 @@
+package id.cachet.wallet.integration
+
+import id.cachet.wallet.domain.model.ConsentDetails
+import id.cachet.wallet.domain.repository.InMemoryConsentReceiptRepository
+import id.cachet.wallet.domain.sync.SyncManager
+import id.cachet.wallet.domain.sync.SyncQueueRepository
+import id.cachet.wallet.domain.usecase.ConsentUseCase
+import id.cachet.wallet.domain.usecase.IssuanceUseCase
+import id.cachet.wallet.network.CredentialResponse
+import id.cachet.wallet.testfixtures.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests validating the full offline queue and sync flow
+ * across ConsentUseCase/IssuanceUseCase → Queue → SyncManager → Repository.
+ *
+ * Each test wires real use cases to a shared FakeSyncQueueRepository
+ * that SyncManager reads from, proving state crosses component boundaries.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SyncIntegrationTest {
+
+    private val validConsent = ConsentDetails(
+        explicitConsent = true,
+        dataMinimizationAcknowledged = true,
+        retentionPeriodUnderstood = true,
+        retentionPeriodDays = 90
+    )
+
+    // ── Flow A: receipt offline → enqueued → sync → anchored ──
+
+    @Test
+    fun `receipt generated offline is anchored after reconnect`() = runTest {
+        // Shared state between ConsentUseCase and SyncManager
+        val queueRepo = FakeSyncQueueRepository()
+        val consentRepo = InMemoryConsentReceiptRepository()
+        val logRepo = ControllableTransparencyLogRepository()
+        val connectivity = FakeConnectivityObserver(initialOnline = false)
+
+        // ConsentUseCase uses an AnchoringQueue backed by the same queueRepo
+        val anchoringQueue = InMemoryAnchoringQueue(queueRepo)
+        val consentUseCase = ConsentUseCase(
+            credentialRepository = FakeCredentialRepository(),
+            consentReceiptRepository = consentRepo,
+            transparencyLogRepository = logRepo,
+            anchoringQueue = anchoringQueue
+        )
+
+        val syncManager = SyncManager(
+            connectivity = connectivity,
+            queueRepository = queueRepo,
+            consentReceiptRepository = consentRepo,
+            transparencyLogRepository = logRepo,
+            openID4VCIClient = FakeOpenID4VCIClient(),
+            credentialRepository = FakeCredentialRepository(),
+            scope = this
+        )
+        syncManager.start()
+
+        // Phase 1: Generate receipt while transparency log is unavailable
+        logRepo.shouldFail = true
+        val result = consentUseCase.generateConsentReceipt(
+            credential = makeCredential(),
+            presentationRequest = makePresentationRequest(),
+            userConsent = validConsent
+        )
+
+        assertTrue(result.isSuccess, "Receipt should succeed even when anchoring fails")
+        val receipt = result.getOrThrow()
+        assertNull(receipt.transparencyLogEntry, "Receipt should not be anchored yet")
+
+        // Verify receipt is stored AND enqueued
+        val stored = consentRepo.getReceiptById(receipt.id).getOrThrow()
+        assertNotNull(stored, "Receipt should be persisted")
+        assertEquals(1, queueRepo.anchoringItems.size, "Receipt should be enqueued for later anchoring")
+        assertEquals(receipt.id, queueRepo.anchoringItems[0].receiptId)
+
+        // Phase 2: Restore connectivity with working transparency log
+        logRepo.shouldFail = false
+        connectivity.goOnline()
+        advanceUntilIdle()
+
+        // Verify: queue drained, receipt NOT updated in repo yet (updateTransparencyLog
+        // is called on the repo, but InMemoryConsentReceiptRepository.updateTransparencyLog
+        // is a no-op for the in-memory impl — the important assertion is that the queue is empty)
+        syncManager.refreshPendingCount()
+        assertEquals(0, syncManager.pendingCount.value, "Queue should be fully drained after sync")
+        assertEquals(0, queueRepo.anchoringItems.size, "Anchoring item should be removed from queue")
+    }
+
+    // ── Flow B: issuance fails mid-flow → enqueued → sync → credential stored ──
+
+    @Test
+    fun `issuance queued offline is completed after reconnect`() = runTest {
+        val queueRepo = FakeSyncQueueRepository()
+        val credentialRepo = FakeCredentialRepository()
+        val connectivity = FakeConnectivityObserver(initialOnline = false)
+
+        // Client: token succeeds, credential fails initially
+        val client = FakeOpenID4VCIClient(
+            credentialError = RuntimeException("Network unavailable")
+        )
+
+        val issuanceQueue = InMemoryIssuanceQueue(queueRepo)
+        val issuanceUseCase = IssuanceUseCase(
+            credentialRepository = credentialRepo,
+            openID4VCIClient = client,
+            issuanceQueue = issuanceQueue
+        )
+
+        val syncManager = SyncManager(
+            connectivity = connectivity,
+            queueRepository = queueRepo,
+            consentReceiptRepository = InMemoryConsentReceiptRepository(),
+            transparencyLogRepository = ControllableTransparencyLogRepository(),
+            openID4VCIClient = client,
+            credentialRepository = credentialRepo,
+            scope = this
+        )
+        syncManager.start()
+
+        // Phase 1: Attempt issuance — token succeeds, credential fetch fails
+        val result = issuanceUseCase.requestCredential(
+            clientId = "cachet-android-wallet",
+            credentialTypes = listOf("VerifiableCredential", "IdentityCredential"),
+            sessionId = "veriff-session-1"
+        )
+
+        assertTrue(result.isFailure, "Issuance should fail when credential fetch fails")
+        assertEquals(1, queueRepo.issuanceItems.size, "Partial state should be enqueued")
+
+        val queued = queueRepo.issuanceItems[0]
+        assertEquals("cachet-android-wallet", queued.clientId)
+        assertEquals("fake-token", queued.accessToken, "Token should be preserved in queue")
+        assertEquals("veriff-session-1", queued.sessionId)
+        assertTrue(queued.tokenExpiresAt > 0, "Token expiry should be set")
+        assertEquals(0, credentialRepo.getAllCredentials().size, "No credential stored yet")
+
+        // Phase 2: Fix the client and restore connectivity
+        client.credentialError = null
+        client.credentialResponse = CredentialResponse(
+            credential = makeCredential(),
+            format = "jwt_vc"
+        )
+        connectivity.goOnline()
+        advanceUntilIdle()
+
+        // Verify: credential issued and queue drained
+        syncManager.refreshPendingCount()
+        assertEquals(0, syncManager.pendingCount.value, "Queue should be drained")
+        assertEquals(1, credentialRepo.getAllCredentials().size, "Credential should be stored after sync")
+    }
+
+    // ── Flow C: token expires while offline → marked expired ──
+
+    @Test
+    fun `expired token issuance is not retried after reconnect`() = runTest {
+        val queueRepo = FakeSyncQueueRepository()
+        val credentialRepo = FakeCredentialRepository()
+        val connectivity = FakeConnectivityObserver(initialOnline = false)
+
+        // Manually enqueue an issuance with an already-expired token
+        // (simulates: user went offline, came back hours later)
+        val expiredAt = kotlin.time.Clock.System.now().toEpochMilliseconds() - 3_600_000L
+        queueRepo.issuanceItems.add(
+            SyncQueueRepository.PendingIssuanceItem(
+                id = "issuance-stale",
+                clientId = "cachet-android-wallet",
+                credentialTypesJson = """["VerifiableCredential"]""",
+                format = "jwt_vc",
+                sessionId = "old-session",
+                accessToken = "expired-token",
+                tokenExpiresAt = expiredAt,
+                keyAlias = null,
+                holderJwk = null,
+                retryCount = 0,
+                status = "pending"
+            )
+        )
+
+        val syncManager = SyncManager(
+            connectivity = connectivity,
+            queueRepository = queueRepo,
+            consentReceiptRepository = InMemoryConsentReceiptRepository(),
+            transparencyLogRepository = ControllableTransparencyLogRepository(),
+            openID4VCIClient = FakeOpenID4VCIClient(),
+            credentialRepository = credentialRepo,
+            scope = this
+        )
+        syncManager.start()
+
+        // Go online
+        connectivity.goOnline()
+        advanceUntilIdle()
+
+        // Verify: expired items are cleaned up, no credential stored
+        syncManager.refreshPendingCount()
+        assertEquals(0, syncManager.pendingCount.value, "Expired item should be removed")
+        assertEquals(0, credentialRepo.getAllCredentials().size, "No credential should be issued with expired token")
+    }
+
+    // ── Flow D: already-anchored receipt → idempotently skipped ──
+
+    @Test
+    fun `already-anchored receipt in queue is cleaned up without API calls`() = runTest {
+        val queueRepo = FakeSyncQueueRepository()
+        val consentRepo = InMemoryConsentReceiptRepository()
+        val logRepo = ControllableTransparencyLogRepository()
+        val connectivity = FakeConnectivityObserver(initialOnline = false)
+
+        // Store a receipt that was already successfully anchored
+        val receipt = makeConsentReceipt(id = "receipt-already-anchored")
+            .copy(
+                receiptHash = "hash",
+                salt = "salt",
+                signature = "sig",
+                transparencyLogEntry = id.cachet.wallet.domain.model.TransparencyLogEntry(
+                    logId = "log-1",
+                    logIndex = 42
+                )
+            )
+        consentRepo.storeReceipt(receipt)
+
+        // But it's still in the queue (e.g., crash before queue cleanup)
+        queueRepo.anchoringItems.add(
+            SyncQueueRepository.PendingAnchoringItem("receipt-already-anchored", 0, "pending")
+        )
+
+        val syncManager = SyncManager(
+            connectivity = connectivity,
+            queueRepository = queueRepo,
+            consentReceiptRepository = consentRepo,
+            transparencyLogRepository = logRepo,
+            openID4VCIClient = FakeOpenID4VCIClient(),
+            credentialRepository = FakeCredentialRepository(),
+            scope = this
+        )
+        syncManager.start()
+
+        // Make log fail — if SyncManager incorrectly tries to re-anchor, it would fail
+        logRepo.shouldFail = true
+        connectivity.goOnline()
+        advanceUntilIdle()
+
+        // Verify: item removed from queue even though log is failing
+        // (because idempotency check sees transparencyLogEntry is already set)
+        syncManager.refreshPendingCount()
+        assertEquals(0, syncManager.pendingCount.value, "Already-anchored receipt should be cleaned up")
+        assertEquals(0, queueRepo.anchoringItems.size)
+    }
+
+    // ── Flow E: max retries exceeded → marked failed, stops retrying ──
+
+    @Test
+    fun `anchoring stops retrying after max attempts`() = runTest {
+        val queueRepo = FakeSyncQueueRepository()
+        val consentRepo = InMemoryConsentReceiptRepository()
+        val logRepo = ControllableTransparencyLogRepository()
+        logRepo.shouldFail = true
+        val connectivity = FakeConnectivityObserver(initialOnline = true)
+
+        val anchoringQueue = InMemoryAnchoringQueue(queueRepo)
+        val consentUseCase = ConsentUseCase(
+            credentialRepository = FakeCredentialRepository(),
+            consentReceiptRepository = consentRepo,
+            transparencyLogRepository = logRepo,
+            anchoringQueue = anchoringQueue
+        )
+
+        val syncManager = SyncManager(
+            connectivity = connectivity,
+            queueRepository = queueRepo,
+            consentReceiptRepository = consentRepo,
+            transparencyLogRepository = logRepo,
+            openID4VCIClient = FakeOpenID4VCIClient(),
+            credentialRepository = FakeCredentialRepository(),
+            scope = this
+        )
+
+        // Phase 1: Generate receipt offline (log fails, enqueued)
+        val result = consentUseCase.generateConsentReceipt(
+            credential = makeCredential(),
+            presentationRequest = makePresentationRequest(),
+            userConsent = validConsent
+        )
+        assertTrue(result.isSuccess)
+        assertEquals(1, queueRepo.anchoringItems.size)
+
+        // Phase 2: Retry MAX_RETRY_COUNT times — all fail
+        repeat(SyncManager.MAX_RETRY_COUNT) {
+            syncManager.triggerSync()
+            advanceUntilIdle()
+        }
+
+        // Verify: item marked as failed, no longer in pending count
+        assertEquals(1, queueRepo.anchoringItems.size, "Item should still exist but be marked failed")
+        assertEquals("failed", queueRepo.anchoringItems[0].status)
+        assertEquals(SyncManager.MAX_RETRY_COUNT.toLong(), queueRepo.anchoringItems[0].retryCount)
+        syncManager.refreshPendingCount()
+        assertEquals(0, syncManager.pendingCount.value, "Failed items should not count as pending")
+
+        // Phase 3: One more sync — failed items are NOT retried
+        val retryCountBefore = queueRepo.anchoringItems[0].retryCount
+        syncManager.triggerSync()
+        advanceUntilIdle()
+
+        assertEquals(retryCountBefore, queueRepo.anchoringItems[0].retryCount,
+            "Failed items should not be retried — retry count should not increase")
+        assertEquals("failed", queueRepo.anchoringItems[0].status)
+    }
+}

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/ControllableTransparencyLogRepository.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/ControllableTransparencyLogRepository.kt
@@ -1,0 +1,47 @@
+package id.cachet.wallet.testfixtures
+
+import id.cachet.wallet.domain.model.*
+import id.cachet.wallet.domain.repository.MockTransparencyLogRepository
+import id.cachet.wallet.domain.repository.TransparencyLogRepository
+
+/**
+ * Transparency log repository that can be toggled between failing and succeeding.
+ * When [shouldFail] is true, submitReceiptHash returns failure; otherwise delegates to mock.
+ */
+class ControllableTransparencyLogRepository : TransparencyLogRepository {
+
+    var shouldFail: Boolean = false
+
+    private val delegate = MockTransparencyLogRepository()
+
+    override suspend fun submitReceiptHash(request: AddEntryRequest): Result<AddEntryResponse> {
+        if (shouldFail) return Result.failure(RuntimeException("Network unavailable"))
+        return delegate.submitReceiptHash(request)
+    }
+
+    override suspend fun getCurrentSTH(): Result<SignedTreeHead> {
+        if (shouldFail) return Result.failure(RuntimeException("Network unavailable"))
+        return delegate.getCurrentSTH()
+    }
+
+    override suspend fun getEntries(start: Long, end: Long): Result<List<LogEntry>> {
+        if (shouldFail) return Result.failure(RuntimeException("Network unavailable"))
+        return delegate.getEntries(start, end)
+    }
+
+    override suspend fun getInclusionProof(leafIndex: Long, treeSize: Long): Result<InclusionProof> {
+        if (shouldFail) return Result.failure(RuntimeException("Network unavailable"))
+        return delegate.getInclusionProof(leafIndex, treeSize)
+    }
+
+    override suspend fun getConsistencyProof(firstTreeSize: Long, secondTreeSize: Long): Result<ConsistencyProof> {
+        if (shouldFail) return Result.failure(RuntimeException("Network unavailable"))
+        return delegate.getConsistencyProof(firstTreeSize, secondTreeSize)
+    }
+
+    override fun verifyInclusionProof(leafHash: String, proof: InclusionProof): Boolean =
+        delegate.verifyInclusionProof(leafHash, proof)
+
+    override fun verifyConsistencyProof(firstSTH: SignedTreeHead, secondSTH: SignedTreeHead, proof: ConsistencyProof): Boolean =
+        delegate.verifyConsistencyProof(firstSTH, secondSTH, proof)
+}

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/FakeAnchoringQueue.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/FakeAnchoringQueue.kt
@@ -1,0 +1,11 @@
+package id.cachet.wallet.testfixtures
+
+import id.cachet.wallet.domain.sync.AnchoringQueue
+
+class FakeAnchoringQueue : AnchoringQueue {
+    val enqueuedReceiptIds = mutableListOf<String>()
+
+    override suspend fun enqueue(receiptId: String) {
+        enqueuedReceiptIds.add(receiptId)
+    }
+}

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/FakeConnectivityObserver.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/FakeConnectivityObserver.kt
@@ -1,0 +1,14 @@
+package id.cachet.wallet.testfixtures
+
+import id.cachet.wallet.domain.sync.ConnectivityObserver
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class FakeConnectivityObserver(initialOnline: Boolean = true) : ConnectivityObserver {
+    private val _isOnline = MutableStateFlow(initialOnline)
+    override val isOnline: StateFlow<Boolean> = _isOnline
+
+    fun setOnline(online: Boolean) { _isOnline.value = online }
+    fun goOffline() = setOnline(false)
+    fun goOnline() = setOnline(true)
+}

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/FakeIssuanceQueue.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/FakeIssuanceQueue.kt
@@ -1,0 +1,12 @@
+package id.cachet.wallet.testfixtures
+
+import id.cachet.wallet.domain.sync.IssuanceQueue
+import id.cachet.wallet.domain.sync.PendingIssuanceState
+
+class FakeIssuanceQueue : IssuanceQueue {
+    val enqueuedStates = mutableListOf<PendingIssuanceState>()
+
+    override suspend fun enqueue(state: PendingIssuanceState) {
+        enqueuedStates.add(state)
+    }
+}

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/FakeOpenID4VCIClient.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/FakeOpenID4VCIClient.kt
@@ -16,7 +16,8 @@ class FakeOpenID4VCIClient(
     var credentialResponse: CredentialResponse? = null,
     var sdJwtCredentialResponse: SDJWTCredentialResponse? = null,
     var tokenError: Throwable? = null,
-    var credentialError: Throwable? = null
+    var credentialError: Throwable? = null,
+    var sdJwtCredentialError: Throwable? = null
 ) : OpenID4VCIClient {
 
     override suspend fun requestToken(clientId: String, scope: String, sessionId: String?): TokenResponse {
@@ -43,6 +44,7 @@ class FakeOpenID4VCIClient(
         holderJWK: String,
         proofJWT: String?
     ): SDJWTCredentialResponse {
+        sdJwtCredentialError?.let { throw it }
         return sdJwtCredentialResponse ?: error("FakeOpenID4VCIClient: sdJwtCredentialResponse not configured")
     }
 }

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/FakeSyncQueueRepository.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/FakeSyncQueueRepository.kt
@@ -1,0 +1,65 @@
+package id.cachet.wallet.testfixtures
+
+import id.cachet.wallet.domain.sync.SyncQueueRepository
+
+class FakeSyncQueueRepository : SyncQueueRepository {
+
+    val anchoringItems = mutableListOf<SyncQueueRepository.PendingAnchoringItem>()
+    val issuanceItems = mutableListOf<SyncQueueRepository.PendingIssuanceItem>()
+
+    // ── Anchoring ──
+
+    override suspend fun getPendingAnchorings(): List<SyncQueueRepository.PendingAnchoringItem> {
+        return anchoringItems.filter { it.status == "pending" }
+    }
+
+    override suspend fun deletePendingAnchoring(receiptId: String) {
+        anchoringItems.removeAll { it.receiptId == receiptId }
+    }
+
+    override suspend fun updatePendingAnchoringStatus(
+        receiptId: String, status: String, retryCount: Long, lastAttemptAt: Long
+    ) {
+        val index = anchoringItems.indexOfFirst { it.receiptId == receiptId }
+        if (index >= 0) {
+            anchoringItems[index] = anchoringItems[index].copy(
+                status = status,
+                retryCount = retryCount
+            )
+        }
+    }
+
+    // ── Issuance ──
+
+    override suspend fun deleteExpiredIssuances(nowMillis: Long) {
+        issuanceItems.removeAll { it.tokenExpiresAt < nowMillis }
+    }
+
+    override suspend fun getPendingIssuances(): List<SyncQueueRepository.PendingIssuanceItem> {
+        return issuanceItems.filter { it.status == "pending" }
+    }
+
+    override suspend fun deletePendingIssuance(id: String) {
+        issuanceItems.removeAll { it.id == id }
+    }
+
+    override suspend fun updatePendingIssuanceStatus(
+        id: String, status: String, retryCount: Long, lastAttemptAt: Long
+    ) {
+        val index = issuanceItems.indexOfFirst { it.id == id }
+        if (index >= 0) {
+            issuanceItems[index] = issuanceItems[index].copy(
+                status = status,
+                retryCount = retryCount
+            )
+        }
+    }
+
+    // ── Counts ──
+
+    override suspend fun getPendingAnchoringCount(): Int =
+        anchoringItems.count { it.status == "pending" }
+
+    override suspend fun getPendingIssuanceCount(): Int =
+        issuanceItems.count { it.status == "pending" }
+}

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/InMemoryAnchoringQueue.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/InMemoryAnchoringQueue.kt
@@ -1,0 +1,25 @@
+package id.cachet.wallet.testfixtures
+
+import id.cachet.wallet.domain.sync.AnchoringQueue
+import id.cachet.wallet.domain.sync.SyncQueueRepository
+import kotlin.time.Clock
+
+/**
+ * AnchoringQueue backed by FakeSyncQueueRepository —
+ * bridges ConsentUseCase enqueue calls to the same store SyncManager reads from.
+ */
+class InMemoryAnchoringQueue(
+    private val queueRepository: FakeSyncQueueRepository,
+    private val clock: Clock = Clock.System
+) : AnchoringQueue {
+
+    override suspend fun enqueue(receiptId: String) {
+        queueRepository.anchoringItems.add(
+            SyncQueueRepository.PendingAnchoringItem(
+                receiptId = receiptId,
+                retryCount = 0,
+                status = "pending"
+            )
+        )
+    }
+}

--- a/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/InMemoryIssuanceQueue.kt
+++ b/mobile/shared/src/commonTest/kotlin/id/cachet/wallet/testfixtures/InMemoryIssuanceQueue.kt
@@ -1,0 +1,34 @@
+package id.cachet.wallet.testfixtures
+
+import id.cachet.wallet.domain.sync.IssuanceQueue
+import id.cachet.wallet.domain.sync.PendingIssuanceState
+import id.cachet.wallet.domain.sync.SyncQueueRepository
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * IssuanceQueue backed by FakeSyncQueueRepository —
+ * bridges IssuanceUseCase enqueue calls to the same store SyncManager reads from.
+ */
+class InMemoryIssuanceQueue(
+    private val queueRepository: FakeSyncQueueRepository
+) : IssuanceQueue {
+
+    override suspend fun enqueue(state: PendingIssuanceState) {
+        queueRepository.issuanceItems.add(
+            SyncQueueRepository.PendingIssuanceItem(
+                id = state.id,
+                clientId = state.clientId,
+                credentialTypesJson = Json.encodeToString(state.credentialTypes),
+                format = state.format,
+                sessionId = state.sessionId,
+                accessToken = state.accessToken,
+                tokenExpiresAt = state.tokenExpiresAt,
+                keyAlias = state.keyAlias,
+                holderJwk = state.holderJwk,
+                retryCount = 0,
+                status = "pending"
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Phase 4 of the offline-first roadmap (#99). Adds persistent queuing for operations that fail due to network loss, with automatic retry when connectivity is restored.

- **Consent receipt anchoring queue**: receipts generated offline are enqueued and anchored to the transparency log within seconds of reconnect
- **Issuance resume**: if credential fetch fails mid-flow (after OAuth token obtained), token + key state is persisted for retry without re-authentication
- **Network status**: ConnectivityObserver (Android ConnectivityManager + StateFlow) surfaces online/offline state to SyncManager and UI
- **SyncManager**: orchestrates queue draining on connectivity restore with retry limits (max 5), token expiry checks (5-min buffer), and idempotency (already-anchored receipts skipped)
- **Bug fix**: queue queries now return only `pending` items, preventing infinite retry of permanently failed items

## Key design decisions

- `SyncQueueRepository` interface abstracts SQLDelight queries for testability — all integration tests run with in-memory fakes
- Queue interfaces (`AnchoringQueue`, `IssuanceQueue`) are nullable on use cases for backward compatibility
- `failed` status is terminal — items stop being retried and stay for user visibility
- Fresh `c_nonce` fetched per issuance retry (single-use, never reuse old one)

## Test plan

- [x] 3 unit tests: ConsentUseCaseOfflineTest (enqueue on fail, no enqueue on success, backward compat)
- [x] 6 unit tests: IssuanceUseCaseOfflineTest (enqueue on credential fail, no enqueue on token fail, backward compat)
- [x] 7 unit tests: SyncManagerTest (drain on reconnect, idempotency, max retries, token expiry, resume issuance)
- [x] 5 integration tests: SyncIntegrationTest (full cross-component flows A-E)
- [x] 64 existing Android unit tests pass (0 failures)
- [ ] Manual: airplane mode toggle on emulator, verify offline banner + queue drain

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)