### PR TITLE
chore: consolidate Dependabot config with multi-directory groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,58 +1,16 @@
 version: 2
 updates:
-  # Go dependencies — grouped so one PR covers all modules
+  # Go dependencies — one PR per weekly batch across all modules
   - package-ecosystem: "gomod"
-    directory: "/services/common"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore(deps)"
-    groups:
-      go-deps:
-        patterns: ["*"]
-
-  - package-ecosystem: "gomod"
-    directory: "/services/verifier"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore(deps)"
-    groups:
-      go-deps:
-        patterns: ["*"]
-
-  - package-ecosystem: "gomod"
-    directory: "/services/registry"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore(deps)"
-    groups:
-      go-deps:
-        patterns: ["*"]
-
-  - package-ecosystem: "gomod"
-    directory: "/services/receipts-log"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore(deps)"
-    groups:
-      go-deps:
-        patterns: ["*"]
-
-  - package-ecosystem: "gomod"
-    directory: "/services/issuance-gateway"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore(deps)"
-    groups:
-      go-deps:
-        patterns: ["*"]
-
-  - package-ecosystem: "gomod"
-    directory: "/generated/go"
+    directories:
+      - "/services/admin"
+      - "/services/common"
+      - "/services/issuance-gateway"
+      - "/services/receipts-log"
+      - "/services/registry"
+      - "/services/relay"
+      - "/services/verifier"
+      - "/generated/go"
     schedule:
       interval: "weekly"
     commit-message:
@@ -82,39 +40,9 @@ updates:
         patterns: ["*"]
         exclude-patterns: ["org.jetbrains.kotlin*", "org.jetbrains.kotlinx*", "io.ktor*", "app.cash.sqldelight*", "androidx.*"]
 
-  # Docker base images — grouped into one PR
+  # Docker base images — single Dockerfile in /infra
   - package-ecosystem: "docker"
-    directory: "/services/verifier"
-    schedule:
-      interval: "monthly"
-    commit-message:
-      prefix: "chore(docker)"
-    groups:
-      docker-base:
-        patterns: ["*"]
-
-  - package-ecosystem: "docker"
-    directory: "/services/registry"
-    schedule:
-      interval: "monthly"
-    commit-message:
-      prefix: "chore(docker)"
-    groups:
-      docker-base:
-        patterns: ["*"]
-
-  - package-ecosystem: "docker"
-    directory: "/services/receipts-log"
-    schedule:
-      interval: "monthly"
-    commit-message:
-      prefix: "chore(docker)"
-    groups:
-      docker-base:
-        patterns: ["*"]
-
-  - package-ecosystem: "docker"
-    directory: "/services/issuance-gateway"
+    directory: "/infra"
     schedule:
       interval: "monthly"
     commit-message:


### PR DESCRIPTION
## Summary
- Replace 6 separate `gomod` entries and 4 separate `docker` entries with single entries using the `directories` key, so shared dependency bumps produce **one PR instead of N**
- Add missing `admin` and `relay` modules to Dependabot coverage
- Point Docker scanning at `/infra` where the actual Dockerfile lives (per-service dirs had none)

Closes #151
Closes #152
Closes #153
Closes #155

## Test plan
- [ ] Verify Dependabot picks up the new config after merge (next weekly run)
- [ ] Confirm PRs #151–#153 and #155 are auto-closed on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)