### PR TITLE
feat: polish liveness, QR scanner screens and unify Activity FABs

### DIFF
--- a/design/wireframes/activity-02-action-sheet.svg
+++ b/design/wireframes/activity-02-action-sheet.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 375 812" width="375" height="812">
+  <!--
+    SCREEN: Activity Action Sheet
+    After tapping the FAB on the Activity tab, a bottom sheet slides up
+    with three labeled actions: Scan QR, Verify in person, New request.
+
+    Design tokens (from Color.kt):
+      SurfaceCard        #FFFFFF   sheet background
+      BrandPrimary       #1E293B   scan QR icon tint
+      BrandAccent        #10B981   verify/new-request icon tint, FAB
+      TextPrimary        #1C1917   action title
+      TextSecondary      #57534E   action subtitle
+      SurfaceBorder      #E7E5E4   (not used — sheet has elevation shadow)
+  -->
+
+  <!-- Dimmed background — activity tab behind the sheet -->
+  <rect width="375" height="812" rx="40" fill="#FAFAF9"/>
+  <rect width="375" height="812" rx="40" fill="#000000" opacity="0.35"/>
+
+  <!-- Bottom sheet — white card, rounded top corners -->
+  <rect x="0" y="460" width="375" height="352" rx="24" fill="#FFFFFF"/>
+
+  <!-- Drag handle -->
+  <rect x="163" y="472" width="50" height="4" rx="2" fill="#E7E5E4"/>
+
+  <!-- Action 1: Scan QR code -->
+  <g transform="translate(24,500)">
+    <!-- Icon circle — BrandPrimary tint at 10% -->
+    <circle cx="20" cy="20" r="20" fill="#1E293B" opacity="0.1"/>
+    <g transform="translate(10,10)">
+      <!-- QR code scanner icon (simplified Material) -->
+      <path d="M 2 0 L 0 0 L 0 2" fill="none" stroke="#1E293B" stroke-width="2" stroke-linecap="round"/>
+      <path d="M 18 0 L 20 0 L 20 2" fill="none" stroke="#1E293B" stroke-width="2" stroke-linecap="round"/>
+      <path d="M 2 20 L 0 20 L 0 18" fill="none" stroke="#1E293B" stroke-width="2" stroke-linecap="round"/>
+      <path d="M 18 20 L 20 20 L 20 18" fill="none" stroke="#1E293B" stroke-width="2" stroke-linecap="round"/>
+      <rect x="6" y="6" width="8" height="8" rx="1" fill="none" stroke="#1E293B" stroke-width="1.5"/>
+    </g>
+    <text x="56" y="14" font-family="Inter, sans-serif" font-size="14" font-weight="600" fill="#1C1917">Scan QR code</text>
+    <text x="56" y="32" font-family="Inter, sans-serif" font-size="12" fill="#57534E">Scan someone's Cachet QR</text>
+  </g>
+
+  <!-- Action 2: Verify in person -->
+  <g transform="translate(24,564)">
+    <!-- Icon circle — BrandAccent tint at 10% -->
+    <circle cx="20" cy="20" r="20" fill="#10B981" opacity="0.1"/>
+    <g transform="translate(10,10)">
+      <!-- NearMe icon (simplified Material) -->
+      <path d="M 10 2 L 18 10 L 10 18 L 2 10 Z" fill="none" stroke="#10B981" stroke-width="2" stroke-linejoin="round"/>
+      <circle cx="10" cy="10" r="3" fill="#10B981"/>
+    </g>
+    <text x="56" y="14" font-family="Inter, sans-serif" font-size="14" font-weight="600" fill="#1C1917">Verify in person</text>
+    <text x="56" y="32" font-family="Inter, sans-serif" font-size="12" fill="#57534E">Proximity verification nearby</text>
+  </g>
+
+  <!-- Action 3: New request -->
+  <g transform="translate(24,628)">
+    <!-- Icon circle — BrandAccent tint at 10% -->
+    <circle cx="20" cy="20" r="20" fill="#10B981" opacity="0.1"/>
+    <g transform="translate(10,10)">
+      <!-- Plus icon (Material Add) -->
+      <line x1="10" y1="4" x2="10" y2="16" stroke="#10B981" stroke-width="2.5" stroke-linecap="round"/>
+      <line x1="4" y1="10" x2="16" y2="10" stroke="#10B981" stroke-width="2.5" stroke-linecap="round"/>
+    </g>
+    <text x="56" y="14" font-family="Inter, sans-serif" font-size="14" font-weight="600" fill="#1C1917">New request</text>
+    <text x="56" y="32" font-family="Inter, sans-serif" font-size="12" fill="#57534E">Create a verification request</text>
+  </g>
+
+</svg>

--- a/design/wireframes/cachet-02-qr-scan.svg
+++ b/design/wireframes/cachet-02-qr-scan.svg
@@ -37,21 +37,12 @@
 
   <!-- Instructions below viewfinder -->
   <rect x="40" y="560" width="295" height="72" rx="16" fill="#1E293B"/>
-  <!-- Lock icon (Material Icons style) — BrandAccent -->
-  <g transform="translate(56,576)">
-    <rect x="2" y="8" width="16" height="12" rx="2" fill="#10B981"/>
-    <path d="M 5 8 V 5 A 5 5 0 0 1 15 5 V 8" fill="none" stroke="#10B981" stroke-width="2" stroke-linecap="round"/>
-  </g>
-  <text x="92" y="586" font-family="Inter, sans-serif" font-size="13" fill="#F5F5F4">You'll review before sharing</text>
-  <text x="92" y="606" font-family="Inter, sans-serif" font-size="12" fill="#64748B">Nothing is shared without your consent</text>
+  <text x="60" y="601" text-anchor="middle" font-family="Inter, sans-serif" font-size="18" fill="#10B981">&#x1F512;</text>
+  <text x="92" y="590" font-family="Inter, sans-serif" font-size="13" fill="#F5F5F4">You'll review before sharing</text>
+  <text x="92" y="610" font-family="Inter, sans-serif" font-size="12" fill="#64748B">Nothing is shared without your consent</text>
 
   <!-- Torch toggle -->
   <circle cx="188" cy="680" r="28" fill="#1E293B"/>
-  <!-- Flashlight icon (Material style) -->
-  <g transform="translate(180,668)">
-    <rect x="2" y="0" width="12" height="8" rx="2" fill="#F5F5F4"/>
-    <rect x="4" y="8" width="8" height="10" rx="1" fill="#F5F5F4"/>
-    <line x1="8" y1="12" x2="8" y2="16" stroke="#1E293B" stroke-width="2" stroke-linecap="round"/>
-  </g>
+  <text x="188" y="687" text-anchor="middle" font-family="Inter, sans-serif" font-size="20" fill="#FFFFFF">&#x1F4A1;</text>
   <text x="188" y="724" text-anchor="middle" font-family="Inter, sans-serif" font-size="11" fill="#64748B">Torch</text>
 </svg>

--- a/design/wireframes/cachet-02-qr-scan.svg
+++ b/design/wireframes/cachet-02-qr-scan.svg
@@ -5,20 +5,20 @@
     Scanning the verifier's QR leads to the Incoming Request screen.
   -->
 
-  <rect width="375" height="812" rx="40" fill="#0F0F0F"/>
+  <rect width="375" height="812" rx="40" fill="#0F172A"/>
 
   <!-- Status bar -->
   <text x="30" y="52" font-family="Inter, sans-serif" font-size="14" font-weight="600" fill="#FFFFFF">9:41</text>
 
   <!-- Close -->
-  <text x="350" y="52" font-family="Inter, sans-serif" font-size="16" fill="#FFFFFF">&#x2715;</text>
+  <text x="350" y="52" font-family="Inter, sans-serif" font-size="16" fill="#A8A29E">&#x2715;</text>
 
   <!-- Title -->
-  <text x="188" y="95" text-anchor="middle" font-family="Inter, sans-serif" font-size="18" font-weight="700" fill="#FFFFFF">Scan to verify</text>
-  <text x="188" y="118" text-anchor="middle" font-family="Inter, sans-serif" font-size="13" fill="#94A3B8">Point your camera at their Cachet QR code</text>
+  <text x="188" y="95" text-anchor="middle" font-family="Inter, sans-serif" font-size="18" font-weight="700" fill="#F5F5F4">Scan to verify</text>
+  <text x="188" y="118" text-anchor="middle" font-family="Inter, sans-serif" font-size="13" fill="#A8A29E">Point your camera at their Cachet QR code</text>
 
   <!-- Camera viewfinder area -->
-  <rect x="32" y="150" width="311" height="380" rx="24" fill="#1A1A1A"/>
+  <rect x="32" y="150" width="311" height="380" rx="24" fill="#1C1917"/>
 
   <!-- Viewfinder corners (top-left) -->
   <path d="M 56 180 L 56 164 Q 56 158 62 158 L 78 158" fill="none" stroke="#10B981" stroke-width="3" stroke-linecap="round"/>
@@ -37,12 +37,21 @@
 
   <!-- Instructions below viewfinder -->
   <rect x="40" y="560" width="295" height="72" rx="16" fill="#1E293B"/>
-  <text x="64" y="588" font-family="Inter, sans-serif" font-size="18" fill="#10B981">&#x1F512;</text>
-  <text x="92" y="586" font-family="Inter, sans-serif" font-size="13" fill="#FFFFFF">You'll review before sharing</text>
+  <!-- Lock icon (Material Icons style) — BrandAccent -->
+  <g transform="translate(56,576)">
+    <rect x="2" y="8" width="16" height="12" rx="2" fill="#10B981"/>
+    <path d="M 5 8 V 5 A 5 5 0 0 1 15 5 V 8" fill="none" stroke="#10B981" stroke-width="2" stroke-linecap="round"/>
+  </g>
+  <text x="92" y="586" font-family="Inter, sans-serif" font-size="13" fill="#F5F5F4">You'll review before sharing</text>
   <text x="92" y="606" font-family="Inter, sans-serif" font-size="12" fill="#64748B">Nothing is shared without your consent</text>
 
   <!-- Torch toggle -->
   <circle cx="188" cy="680" r="28" fill="#1E293B"/>
-  <text x="188" y="687" text-anchor="middle" font-family="Inter, sans-serif" font-size="20" fill="#FFFFFF">&#x1F4A1;</text>
+  <!-- Flashlight icon (Material style) -->
+  <g transform="translate(180,668)">
+    <rect x="2" y="0" width="12" height="8" rx="2" fill="#F5F5F4"/>
+    <rect x="4" y="8" width="8" height="10" rx="1" fill="#F5F5F4"/>
+    <line x1="8" y1="12" x2="8" y2="16" stroke="#1E293B" stroke-width="2" stroke-linecap="round"/>
+  </g>
   <text x="188" y="724" text-anchor="middle" font-family="Inter, sans-serif" font-size="11" fill="#64748B">Torch</text>
 </svg>

--- a/design/wireframes/cachet-03b-liveness-check.svg
+++ b/design/wireframes/cachet-03b-liveness-check.svg
@@ -38,11 +38,18 @@
   <line x1="196" y1="90" x2="221" y2="90" stroke="#334155" stroke-width="2"/>
   <circle cx="228" cy="90" r="8" fill="#334155"/>
 
+  <!-- Pack badge (CachetMark — per-type shield, Childcare shown here) -->
+  <g transform="translate(160,110)">
+    <path d="M 28 2 C 36 8 50 9 54 9 V 32 C 54 45 43 54 28 60 C 13 54 2 45 2 32 V 9 C 6 9 20 8 28 2 Z" fill="#D88AA0"/>
+    <path d="M 28 8 C 34 12 46 14 50 14 V 32 C 50 43 40 50 28 56 C 16 50 6 43 6 32 V 14 C 10 14 22 12 28 8 Z" fill="#263347"/>
+    <path d="M 38 44 A 15 15 0 1 0 18 44" fill="none" stroke="#fff" stroke-width="7" stroke-linecap="round"/>
+  </g>
+
   <!-- Header text -->
-  <text x="188" y="138" text-anchor="middle" font-family="Inter, sans-serif" font-size="22" font-weight="700" fill="#FFFFFF">Prove it&#x2019;s you</text>
-  <text x="188" y="162" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" fill="#A8A29E">A quick identity check is required for</text>
+  <text x="188" y="198" text-anchor="middle" font-family="Inter, sans-serif" font-size="22" font-weight="700" fill="#FFFFFF">Prove it&#x2019;s you</text>
+  <text x="188" y="222" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" fill="#A8A29E">A quick identity check is required for</text>
   <!-- Pack name: color is dynamic per cachet type (shown here as Childcare) -->
-  <text x="188" y="180" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" font-weight="600" fill="#D88AA0">Childcare Readiness</text>
+  <text x="188" y="240" text-anchor="middle" font-family="Inter, sans-serif" font-size="14" font-weight="600" fill="#D88AA0">Childcare Readiness</text>
 
   <!-- Camera viewfinder — large circle for face framing -->
   <circle cx="188" cy="390" r="130" fill="#1E293B" stroke="#334155" stroke-width="2"/>
@@ -68,7 +75,10 @@
 
   <!-- Why this is needed — trust explanation card (BrandPrimary bg, SurfaceBorderDark stroke) -->
   <rect x="32" y="620" width="311" height="60" rx="12" fill="#1E293B" stroke="#334155" stroke-width="1"/>
-  <text x="56" y="645" font-family="Inter, sans-serif" font-size="20" fill="#F59E0B">&#x1F6E1;</text>
+  <!-- Shield icon (Material Icons style) — BrandAccent -->
+  <g transform="translate(48,628)">
+    <path d="M 9 1 L 1 5 V 11 C 1 16 4.5 20.5 9 22 C 13.5 20.5 17 16 17 11 V 5 Z" fill="#10B981"/>
+  </g>
   <text x="80" y="643" font-family="Inter, sans-serif" font-size="12" fill="#A8A29E">This check ensures only <tspan font-weight="600" fill="#FFFFFF">you</tspan> can sign</text>
   <text x="80" y="663" font-family="Inter, sans-serif" font-size="12" fill="#A8A29E">this high-value verification response.</text>
 

--- a/design/wireframes/cachet-03b-liveness-check.svg
+++ b/design/wireframes/cachet-03b-liveness-check.svg
@@ -1,4 +1,23 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 375 812" width="375" height="812">
+  <defs>
+    <symbol id="childcare-shield" viewBox="0 0 400 520">
+      <path d="M 200 35 C 240 60, 348 63, 366 64 V 239 C 366 337, 296 414, 200 453 C 104 414, 34 337, 34 239 V 64 C 52 63, 160 60, 200 35 Z" fill="#D4748E"/>
+      <path d="M 200 51 C 234 68, 334 74, 354 77 V 236 C 354 326, 288 397, 200 434 C 112 397, 46 326, 46 236 V 77 C 66 74, 166 68, 200 51 Z" fill="#B85578"/>
+      <path d="M 200 59 C 230 69, 328 80, 350 79 V 236 C 350 322, 286 393, 200 430 C 114 393, 50 322, 50 236 V 79 C 72 80, 170 69, 200 59 Z" fill="#D88AA0"/>
+      <path d="M 200 67 C 228 77, 322 85, 342 88 V 236 C 342 318, 280 386, 200 420 C 120 386, 58 318, 58 236 V 88 C 78 85, 172 77, 200 67 Z" fill="#263347"/>
+      <path d="M 200 67 C 172 77, 78 85, 58 88 V 236 C 58 318, 120 386, 200 420 Z" fill="#2D3B52"/>
+      <path d="M 200 142 C 280 142, 330 165, 326 278 C 324 347, 268 388, 200 422 Z" fill="#D85B8A"/>
+      <path d="M 200 142 C 120 142, 70 165, 74 278 C 76 347, 132 388, 200 422 Z" fill="#E06B96"/>
+      <path d="M 274 334 A 108 117 0 1 0 126 334" fill="none" stroke="#fff" stroke-width="61" stroke-linecap="round"/>
+      <g transform="matrix(1.3514, 0, 0, 1.3514, -70.28, -51.0)">
+        <circle cx="200" cy="222" r="36" fill="none" stroke="#fff" stroke-width="5" opacity="0.9"/>
+        <circle cx="186" cy="214" r="4" fill="#fff" opacity="0.9"/>
+        <circle cx="214" cy="214" r="4" fill="#fff" opacity="0.9"/>
+        <path d="M 186,234 Q 200,248 214,234" fill="none" stroke="#fff" stroke-width="3.5" stroke-linecap="round" opacity="0.85"/>
+        <path d="M 183,188 Q 192,172 200,182 Q 208,172 217,188" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+      </g>
+    </symbol>
+  </defs>
   <!--
     SCREEN 3b: Liveness Check
     On the HOLDER's phone — after they consented on the Incoming Request screen.
@@ -38,12 +57,8 @@
   <line x1="196" y1="90" x2="221" y2="90" stroke="#334155" stroke-width="2"/>
   <circle cx="228" cy="90" r="8" fill="#334155"/>
 
-  <!-- Pack badge (CachetMark — per-type shield, Childcare shown here) -->
-  <g transform="translate(160,110)">
-    <path d="M 28 2 C 36 8 50 9 54 9 V 32 C 54 45 43 54 28 60 C 13 54 2 45 2 32 V 9 C 6 9 20 8 28 2 Z" fill="#D88AA0"/>
-    <path d="M 28 8 C 34 12 46 14 50 14 V 32 C 50 43 40 50 28 56 C 16 50 6 43 6 32 V 14 C 10 14 22 12 28 8 Z" fill="#263347"/>
-    <path d="M 38 44 A 15 15 0 1 0 18 44" fill="none" stroke="#fff" stroke-width="7" stroke-linecap="round"/>
-  </g>
+  <!-- Pack badge (CachetMark — Childcare shown here; swap symbol for other types) -->
+  <use href="#childcare-shield" x="160" y="108" width="56" height="73"/>
 
   <!-- Header text -->
   <text x="188" y="198" text-anchor="middle" font-family="Inter, sans-serif" font-size="22" font-weight="700" fill="#FFFFFF">Prove it&#x2019;s you</text>
@@ -75,12 +90,12 @@
 
   <!-- Why this is needed — trust explanation card (BrandPrimary bg, SurfaceBorderDark stroke) -->
   <rect x="32" y="620" width="311" height="60" rx="12" fill="#1E293B" stroke="#334155" stroke-width="1"/>
-  <!-- Shield icon (Material Icons style) — BrandAccent -->
-  <g transform="translate(48,628)">
+  <!-- Shield icon (Material Icons style) — BrandAccent, vertically centered in card -->
+  <g transform="translate(48,639)">
     <path d="M 9 1 L 1 5 V 11 C 1 16 4.5 20.5 9 22 C 13.5 20.5 17 16 17 11 V 5 Z" fill="#10B981"/>
   </g>
-  <text x="80" y="643" font-family="Inter, sans-serif" font-size="12" fill="#A8A29E">This check ensures only <tspan font-weight="600" fill="#FFFFFF">you</tspan> can sign</text>
-  <text x="80" y="663" font-family="Inter, sans-serif" font-size="12" fill="#A8A29E">this high-value verification response.</text>
+  <text x="80" y="645" font-family="Inter, sans-serif" font-size="12" fill="#A8A29E">This check ensures only <tspan font-weight="600" fill="#FFFFFF">you</tspan> can sign</text>
+  <text x="80" y="665" font-family="Inter, sans-serif" font-size="12" fill="#A8A29E">this high-value verification response.</text>
 
   <!-- Cancel button (outlined, SurfaceBorderDark stroke, TextSecondaryDark text) -->
   <rect x="32" y="704" width="311" height="44" rx="22" fill="none" stroke="#334155" stroke-width="1"/>

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/BddTestContext.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/BddTestContext.kt
@@ -3,6 +3,7 @@ package id.cachet.wallet.android.bdd
 import android.content.Intent
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -57,6 +58,20 @@ class BddTestContext {
             }
             try { btn.performScrollTo() } catch (_: Throwable) {}
             btn.performClick()
+            rule.waitForIdle()
+        }
+
+        /**
+         * Opens the Activity action sheet and taps the action identified by [actionTag].
+         * Replaces direct fab_scan_qr / fab_in_person / fab_new_request taps.
+         */
+        fun tapActivityAction(
+            rule: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>,
+            actionTag: String
+        ) {
+            rule.onNodeWithTag("fab_actions").performClick()
+            rule.waitForIdle()
+            rule.onNodeWithTag(actionTag).performClick()
             rule.waitForIdle()
         }
 

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/CommonSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/CommonSteps.kt
@@ -175,7 +175,7 @@ class CommonSteps {
                 composeTestRule.waitForIdle()
                 composeTestRule.onNodeWithText("Activity").performClick()
                 composeTestRule.waitForIdle()
-                composeTestRule.onNodeWithTag("fab_new_request").performClick()
+                BddTestContext.tapActivityAction(composeTestRule, "fab_new_request")
             }
         }
         composeTestRule.waitForIdle()
@@ -211,8 +211,7 @@ class CommonSteps {
         // Navigate: Activity tab -> scan QR -> demo auto-scan -> incoming request
         composeTestRule.onNodeWithText("Activity").performClick()
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithTag("fab_scan_qr").performClick()
-        composeTestRule.waitForIdle()
+        BddTestContext.tapActivityAction(composeTestRule, "fab_scan_qr")
         composeTestRule.waitUntil(timeoutMillis = 5000) {
             composeTestRule.onAllNodes(hasTestTag("incoming_request_screen")).fetchSemanticsNodes().isNotEmpty()
         }
@@ -228,7 +227,7 @@ class CommonSteps {
         // Navigate: Activity tab -> FAB new request -> select pack
         composeTestRule.onNodeWithText("Activity").performClick()
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithTag("fab_new_request").performClick()
+        BddTestContext.tapActivityAction(composeTestRule, "fab_new_request")
         composeTestRule.waitForIdle()
         composeTestRule.onAllNodesWithTag("pack_card").onFirst().performClick()
         composeTestRule.waitForIdle()
@@ -248,8 +247,7 @@ class CommonSteps {
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText("Activity").performClick()
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithTag("fab_scan_qr").performClick()
-        composeTestRule.waitForIdle()
+        BddTestContext.tapActivityAction(composeTestRule, "fab_scan_qr")
         composeTestRule.waitUntil(timeoutMillis = 5000) {
             composeTestRule.onAllNodes(hasTestTag("incoming_request_screen")).fetchSemanticsNodes().isNotEmpty()
         }
@@ -261,8 +259,7 @@ class CommonSteps {
     fun theQRScannerIsOpen() {
         composeTestRule.onNodeWithText("Activity").performClick()
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithTag("fab_scan_qr").performClick()
-        composeTestRule.waitForIdle()
+        BddTestContext.tapActivityAction(composeTestRule, "fab_scan_qr")
     }
 
     @When("I press back")

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/LivenessSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/LivenessSteps.kt
@@ -38,8 +38,7 @@ class LivenessSteps {
         // Navigate: Activity tab -> scan QR -> demo auto-scan -> incoming request
         rule.onNodeWithText("Activity").performClick()
         rule.waitForIdle()
-        rule.onNodeWithTag("fab_scan_qr").performClick()
-        rule.waitForIdle()
+        BddTestContext.tapActivityAction(rule, "fab_scan_qr")
         rule.waitUntil(timeoutMillis = 5000) {
             rule.onAllNodesWithTag("incoming_request_screen").fetchSemanticsNodes().isNotEmpty()
         }
@@ -73,8 +72,7 @@ class LivenessSteps {
 
     @Then("the verification is performed without a liveness check")
     fun theVerificationIsPerformedWithoutALivenessCheck() {
-        // Tap "Verify & Share" and expect result screen directly (no liveness screen in between)
-        BddTestContext.tapConsentCta(rule)
+        // The "When I tap Verify & Share" step already tapped the CTA — just assert here.
         rule.waitForIdle()
 
         // Should NOT see liveness screen

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/ProximityVerifySteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/ProximityVerifySteps.kt
@@ -22,8 +22,7 @@ class ProximityVerifySteps {
         // The "In person" FAB opens the proximity pack picker
         when (mode) {
             "In person" -> {
-                rule.onNodeWithTag("fab_in_person").performClick()
-                rule.waitForIdle()
+                BddTestContext.tapActivityAction(rule, "fab_in_person")
             }
         }
     }

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/ScanToVerifySteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/ScanToVerifySteps.kt
@@ -26,20 +26,13 @@ class ScanToVerifySteps {
     // AC-1: Camera viewfinder
     @When("I tap the FAB and select {string}")
     fun iTapTheFABAndSelect(option: String) {
-        when (option) {
-            "Scan" -> {
-                rule.onNodeWithTag("fab_scan_qr").performClick()
-                rule.waitForIdle()
-            }
-            "Verify" -> {
-                rule.onNodeWithTag("fab_in_person").performClick()
-                rule.waitForIdle()
-            }
-            "New request" -> {
-                rule.onNodeWithTag("fab_new_request").performClick()
-                rule.waitForIdle()
-            }
+        val tag = when (option) {
+            "Scan" -> "fab_scan_qr"
+            "Verify" -> "fab_in_person"
+            "New request" -> "fab_new_request"
+            else -> error("Unknown FAB option: $option")
         }
+        BddTestContext.tapActivityAction(rule, tag)
     }
 
     @Then("the QR scanner opens with the camera viewfinder")
@@ -67,8 +60,7 @@ class ScanToVerifySteps {
     fun iHaveScannedAVerifierQRCode() {
         rule.onNodeWithText("Activity").performClick()
         rule.waitForIdle()
-        rule.onNodeWithTag("fab_scan_qr").performClick()
-        rule.waitForIdle()
+        BddTestContext.tapActivityAction(rule, "fab_scan_qr")
         rule.waitUntil(timeoutMillis = 5000) {
             rule.onAllNodes(hasTestTag("incoming_request_screen")).fetchSemanticsNodes().isNotEmpty()
         }

--- a/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/VerificationResultSteps.kt
+++ b/mobile/androidApp/src/androidTest/kotlin/id/cachet/wallet/android/bdd/steps/VerificationResultSteps.kt
@@ -40,8 +40,7 @@ class VerificationResultSteps {
         // Navigate: Activity tab -> scan QR -> auto-scan -> consent -> result
         rule.onNodeWithText("Activity").performClick()
         rule.waitForIdle()
-        rule.onNodeWithTag("fab_scan_qr").performClick()
-        rule.waitForIdle()
+        BddTestContext.tapActivityAction(rule, "fab_scan_qr")
         rule.waitUntil(timeoutMillis = 5000) {
             rule.onAllNodes(hasTestTag("incoming_request_screen")).fetchSemanticsNodes().isNotEmpty()
         }
@@ -116,8 +115,7 @@ class VerificationResultSteps {
     fun iCompleteTheVerificationFlow() {
         rule.onNodeWithText("Activity").performClick()
         rule.waitForIdle()
-        rule.onNodeWithTag("fab_scan_qr").performClick()
-        rule.waitForIdle()
+        BddTestContext.tapActivityAction(rule, "fab_scan_qr")
         rule.waitUntil(timeoutMillis = 5000) {
             rule.onAllNodes(hasTestTag("incoming_request_screen")).fetchSemanticsNodes().isNotEmpty()
         }

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/credentials/ActivityScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/credentials/ActivityScreen.kt
@@ -1,6 +1,7 @@
 package id.cachet.wallet.android.ui.credentials
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
@@ -18,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import id.cachet.wallet.android.ui.components.*
@@ -33,6 +35,7 @@ private fun ActivityFilter.label() = when (this) {
     ActivityFilter.CACHETS -> "Cachets"
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ActivityScreen(
     historyGroups: List<HistoryGroup>,
@@ -138,42 +141,54 @@ fun ActivityScreen(
         }
     }
 
-        Column(
+        // Single FAB — opens action sheet
+        var showActions by remember { mutableStateOf(false) }
+
+        FloatingActionButton(
+            onClick = { showActions = true },
             modifier = Modifier
                 .align(Alignment.BottomEnd)
-                .padding(bottom = 8.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+                .padding(bottom = 8.dp)
+                .testTag("fab_actions"),
+            containerColor = BrandAccent,
+            contentColor = TextOnBrand,
+            shape = CircleShape
         ) {
-            // Scan QR (holder flow)
-            SmallFloatingActionButton(
-                onClick = onScanQr,
-                modifier = Modifier.testTag("fab_scan_qr"),
-                containerColor = BrandPrimary,
-                contentColor = TextOnBrand,
-                shape = CircleShape
+            Icon(Icons.Default.Add, contentDescription = "Verification actions")
+        }
+
+        if (showActions) {
+            ModalBottomSheet(
+                onDismissRequest = { showActions = false },
+                containerColor = SurfaceCard,
+                shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
             ) {
-                Icon(Icons.Default.QrCodeScanner, contentDescription = "Scan QR")
-            }
-            // In-person verify (proximity)
-            SmallFloatingActionButton(
-                onClick = onInPersonVerify,
-                modifier = Modifier.testTag("fab_in_person"),
-                containerColor = Color(0xFF10B981),
-                contentColor = Color.White,
-                shape = CircleShape
-            ) {
-                Icon(Icons.Default.NearMe, contentDescription = "In-person verification")
-            }
-            // New request (verifier flow)
-            FloatingActionButton(
-                onClick = onStartVerification,
-                modifier = Modifier.testTag("fab_new_request"),
-                containerColor = BrandAccent,
-                contentColor = TextOnBrand,
-                shape = CircleShape
-            ) {
-                Icon(Icons.Default.Add, contentDescription = "New verification request")
+                Column(modifier = Modifier.padding(bottom = 32.dp)) {
+                    ActionRow(
+                        icon = Icons.Default.QrCodeScanner,
+                        iconColor = BrandPrimary,
+                        title = "Scan QR code",
+                        subtitle = "Scan someone's Cachet QR",
+                        testTag = "fab_scan_qr",
+                        onClick = { showActions = false; onScanQr() }
+                    )
+                    ActionRow(
+                        icon = Icons.Default.NearMe,
+                        iconColor = BrandAccent,
+                        title = "Verify in person",
+                        subtitle = "Proximity verification nearby",
+                        testTag = "fab_in_person",
+                        onClick = { showActions = false; onInPersonVerify() }
+                    )
+                    ActionRow(
+                        icon = Icons.Default.Add,
+                        iconColor = BrandAccent,
+                        title = "New request",
+                        subtitle = "Create a verification request",
+                        testTag = "fab_new_request",
+                        onClick = { showActions = false; onStartVerification() }
+                    )
+                }
             }
         }
     }
@@ -312,6 +327,53 @@ private fun AuditSummaryBar(result: String?) {
                 text = if (result != null) "Just now" else "—",
                 style = MaterialTheme.typography.labelSmall,
                 color = TrustNeutral
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActionRow(
+    icon: ImageVector,
+    iconColor: Color,
+    title: String,
+    subtitle: String,
+    testTag: String,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 24.dp, vertical = 14.dp)
+            .testTag(testTag),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Surface(
+            modifier = Modifier.size(40.dp),
+            shape = CircleShape,
+            color = iconColor.copy(alpha = 0.1f)
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                    tint = iconColor
+                )
+            }
+        }
+        Spacer(modifier = Modifier.width(16.dp))
+        Column {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = TextSecondary
             )
         }
     }

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/LivenessCheckScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/LivenessCheckScreen.kt
@@ -230,7 +230,10 @@ fun LivenessCheckScreen(
                 color = BrandPrimary,
                 border = androidx.compose.foundation.BorderStroke(1.dp, SurfaceBorderDark)
             ) {
-                Row(modifier = Modifier.padding(16.dp)) {
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
                     Icon(
                         Icons.Default.Shield,
                         contentDescription = null,

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/LivenessCheckScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/LivenessCheckScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.PriorityHigh
+import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -21,7 +22,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import id.cachet.wallet.android.ui.components.CachetMark
 import id.cachet.wallet.android.ui.components.CachetType
 import id.cachet.wallet.android.ui.components.SealButton
 import id.cachet.wallet.android.ui.theme.*
@@ -155,7 +156,17 @@ fun LivenessCheckScreen(
             // ── Step indicator ──
             StepIndicator(listOf(StepState.DONE, StepState.ACTIVE, StepState.PENDING))
 
-            Spacer(modifier = Modifier.height(32.dp))
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // ── Pack badge ──
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                CachetMark(type = cachetType, size = 56.dp)
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
 
             // ── Header ──
             Text(
@@ -220,7 +231,12 @@ fun LivenessCheckScreen(
                 border = androidx.compose.foundation.BorderStroke(1.dp, SurfaceBorderDark)
             ) {
                 Row(modifier = Modifier.padding(16.dp)) {
-                    Text("\uD83D\uDEE1\uFE0F", fontSize = 16.sp)
+                    Icon(
+                        Icons.Default.Shield,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                        tint = BrandAccent
+                    )
                     Spacer(modifier = Modifier.width(12.dp))
                     Text(
                         text = "This check ensures only you can sign this high-value verification response.",

--- a/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/QrScannerScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/id/cachet/wallet/android/ui/verification/QrScannerScreen.kt
@@ -19,13 +19,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FlashlightOn
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -82,7 +82,7 @@ fun QrScannerScreen(
 
     Surface(
         modifier = Modifier.fillMaxSize(),
-        color = Color(0xFF0F0F0F)
+        color = SurfaceBackgroundDark
     ) {
         Box(modifier = Modifier.fillMaxSize().testTag("qr_scanner_screen")) {
             Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
@@ -90,9 +90,9 @@ fun QrScannerScreen(
                 Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp)) {
                     Text(
                         text = "Scan to verify",
-                        style = MaterialTheme.typography.titleMedium.copy(fontSize = 18.sp),
+                        style = MaterialTheme.typography.titleLarge,
                         fontWeight = FontWeight.Bold,
-                        color = Color.White,
+                        color = TextPrimaryDark,
                         textAlign = TextAlign.Center,
                         modifier = Modifier.align(Alignment.Center)
                     )
@@ -103,14 +103,14 @@ fun QrScannerScreen(
                         Icon(
                             Icons.Default.Close,
                             contentDescription = "Close",
-                            tint = Color.White
+                            tint = TextSecondaryDark
                         )
                     }
                 }
                 Text(
                     text = "Point your camera at their Cachet QR code",
                     style = MaterialTheme.typography.bodySmall,
-                    color = Color(0xFF94A3B8),
+                    color = TextSecondaryDark,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.fillMaxWidth().padding(top = 4.dp)
                 )
@@ -128,7 +128,7 @@ fun QrScannerScreen(
                     Surface(
                         modifier = Modifier.fillMaxSize(),
                         shape = RoundedCornerShape(24.dp),
-                        color = Color(0xFF1A1A1A)
+                        color = SurfaceCardDark
                     ) {
                         if (hasCameraPermission && !demoMode) {
                             CameraPreview(
@@ -149,7 +149,7 @@ fun QrScannerScreen(
                                 Text(
                                     text = if (demoMode) "Scanning..." else "Camera permission required",
                                     style = MaterialTheme.typography.bodySmall,
-                                    color = Color(0xFF64748B)
+                                    color = TextTertiaryDark
                                 )
                             }
                         }
@@ -173,21 +173,23 @@ fun QrScannerScreen(
                         modifier = Modifier.padding(16.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Text(
-                            text = "\uD83D\uDD12",
-                            style = MaterialTheme.typography.titleMedium
+                        Icon(
+                            Icons.Default.Lock,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                            tint = BrandAccent
                         )
                         Spacer(modifier = Modifier.width(12.dp))
                         Column {
                             Text(
                                 text = "You'll review before sharing",
                                 style = MaterialTheme.typography.bodyMedium.copy(fontSize = 13.sp),
-                                color = Color.White
+                                color = TextPrimaryDark
                             )
                             Text(
                                 text = "Nothing is shared without your consent",
                                 style = MaterialTheme.typography.labelSmall,
-                                color = Color(0xFF64748B)
+                                color = TextTertiaryDark
                             )
                         }
                     }
@@ -203,7 +205,7 @@ fun QrScannerScreen(
                     FloatingActionButton(
                         onClick = { torchEnabled = !torchEnabled },
                         containerColor = BrandPrimary,
-                        contentColor = Color.White,
+                        contentColor = TextPrimaryDark,
                         shape = CircleShape,
                         modifier = Modifier.size(56.dp)
                     ) {
@@ -216,7 +218,7 @@ fun QrScannerScreen(
                     Text(
                         text = "Torch",
                         style = MaterialTheme.typography.labelSmall,
-                        color = Color(0xFF64748B)
+                        color = TextTertiaryDark
                     )
                 }
 

--- a/spec/wallet/verification-flow/stories/scan-to-verify/scenarios.feature
+++ b/spec/wallet/verification-flow/stories/scan-to-verify/scenarios.feature
@@ -17,7 +17,7 @@ Feature: Scan to Verify
     And the "happy" demo scenario is loaded
 
   # AC-1: Camera viewfinder
-  @wireframe:cachet-02-qr-scan.svg
+  @wireframe:activity-02-action-sheet.svg @wireframe:cachet-02-qr-scan.svg
   Scenario: Opening QR scanner
     Given I am on the "Activity" tab
     When I tap the FAB and select "Scan"


### PR DESCRIPTION
## Summary
- Replace hardcoded colors with design tokens and emoji glyphs with Material Icons on QrScannerScreen and LivenessCheckScreen to match the Cachet design language
- Replace the confusing triple-FAB stack on the Activity tab with a single FAB that opens a ModalBottomSheet with three clearly labeled actions (Scan QR, Verify in person, New request)
- Fix pre-existing BDD bug: double-tap in "Low-value cachet skips liveness check" scenario
- Update wireframes to reflect all visual changes + new action sheet wireframe

Closes #127

## Test plan
- [x] `android:build` passes
- [x] `android:test-unit` passes
- [ ] `android:bdd` — liveness skip scenario no longer double-taps
- [x] Visual review on S24 Ultra emulator: QR scanner, Activity FAB + bottom sheet
- [ ] Visual review: liveness check screen, liveness failed screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)